### PR TITLE
Fix errors when starting cmld after yocto build

### DIFF
--- a/config_overlay/x86/device.conf
+++ b/config_overlay/x86/device.conf
@@ -2,7 +2,7 @@ uuid: "00000000-0000-0000-0000-000000000000"
 mdm_node: "127.0.0.1"
 mdm_service: "8888"
 update_base_url: "http://127.0.0.1:8000/trustme"
-c0os: "idsos"
+c0os: "trustx-coreos"
 host_addr: "10.0.2.15"
 host_subnet: 24
 host_if: "eth0"

--- a/config_overlay/x86/trustx-core.conf
+++ b/config_overlay/x86/trustx-core.conf
@@ -20,3 +20,4 @@ description {
 }
 feature_bg_booting: true
 feature_devtmpfs: true
+feature_vpn: true


### PR DESCRIPTION
Fix errors during startup of cmld occuring when following instructions at
https://github.com/trustm3/trustme_build/blob/master/yocto/README.md

(trustx-guests directory will be copied to data image by recipe trustx-cml-userdata if https://github.com/trustm3/meta-trustx/pull/4 gets accepted)