### PR TITLE
Quickfix for bug in upstream meta-java

### DIFF
--- a/yocto/init_ws_ids.sh
+++ b/yocto/init_ws_ids.sh
@@ -100,4 +100,8 @@ if [ ${SKIP_CONFIG} != 1 ]; then
 
 fi
 
+#quickfix for bug in upstream meta-java
+mkdir -p ${BUILD_DIR}/meta-appends/classes
+ln -s "${SRC_DIR}/poky/meta/classes/distro_features_check.bbclass" "${BUILD_DIR}/meta-appends/classes/features_check.bbclass"
+
 do_link_devrepo


### PR DESCRIPTION
The upstream meta-java layer tries to inherit features_test.bbclass
in zeus branch which is not present in the zeus version of poky.
Therefore, replace features_test by distro_features_test until upstream is fixed