### PR TITLE
remove c0os from device.conf

### DIFF
--- a/config_overlay/x86/device.conf
+++ b/config_overlay/x86/device.conf
@@ -2,7 +2,6 @@ uuid: "00000000-0000-0000-0000-000000000000"
 mdm_node: "127.0.0.1"
 mdm_service: "8888"
 update_base_url: "http://127.0.0.1:8000/trustme"
-c0os: "trustx-coreos"
 host_addr: "10.0.2.15"
 host_subnet: 24
 host_if: "eth0"


### PR DESCRIPTION
The default c0os is set in CML device.proto rather than in here.