### PR TITLE
enable conditional build of sc-hsm support

### DIFF
--- a/yocto/init_ws_ids.sh
+++ b/yocto/init_ws_ids.sh
@@ -111,6 +111,13 @@ if [ ${SKIP_CONFIG} != 1 ]; then
 	sed -i 's/BBFILE_PRIORITY_meta-appends = "[[:digit:]]"/BBFILE_PRIORITY_meta-appends = "8"/' ${BUILD_DIR}/meta-appends/conf/layer.conf
 
 	sed -i "s/# random string to ignore SSTATE_MIRROR/# random string to ignore SSTATE_MIRROR: $(date +%s | sha1sum | awk '{print $1}')/" "${SRC_DIR}/meta-trustx/recipes-trustx/userdata/pki-native.bb"
+
+	if [ "${ENABLE_SCHSM}" = "1" ]; then
+		echo "Enabling sc-hsm support"
+		sed -i 's/\(TRUSTME_SCHSM = "\)n/\1y/' ${BUILD_DIR}/conf/local.conf
+	fi
+
 fi
+
 
 do_link_devrepo

--- a/yocto/x86/genericx86-64/local.conf
+++ b/yocto/x86/genericx86-64/local.conf
@@ -13,6 +13,8 @@ TRUSTME_CONTAINER_ARCH_${MACHINE}="qemux86-64"
 TRUSTME_HARDWARE = "x86"
 TRUSTME_LOGTTY = "tty11"
 
+TRUSTME_SCHSM = "n"
+
 PACKAGE_CLASSES = "package_ipk"
 BBMULTICONFIG = "container installer"
 


### PR DESCRIPTION
This PR enables the user to decide whether the support for usb token through software provided by CardContact [1] should be built into trustm3.

If the support is desired the user needs to set the env variable ```ENABLE_SCHSM``` to ```1``` prior to sourcing the init_ws.sh skript.

This PR is related to [2] which actually includes the Bibake recipe for the sc-hsm components.

[1] https://github.com/CardContact/sc-hsm-embedded
[2] https://github.com/trustm3/meta-trustx/pull/105