### PR TITLE
yocto/init_ws_ids.sh: enable SecureBoot support in OVMF

### DIFF
--- a/yocto/init_ws_ids.sh
+++ b/yocto/init_ws_ids.sh
@@ -117,6 +117,8 @@ if [ ${SKIP_CONFIG} != 1 ]; then
 		sed -i 's/\(TRUSTME_SCHSM = "\)n/\1y/' ${BUILD_DIR}/conf/local.conf
 	fi
 
+	# enable SecureBoot support in OVMF
+	echo 'PACKAGECONFIG_append_pn-ovmf = " secureboot"' >> out-yocto/conf/local.conf
 fi
 
 


### PR DESCRIPTION
By default the yocto recipe build OVMF without support for secure boot. This PR overrides this behaviour and sets the appropriate "PACKAGECONFIG" value in the local.conf