### PR TITLE
Updated Dockerfile + script for build container

### DIFF
--- a/yocto/docker/Dockerfile
+++ b/yocto/docker/Dockerfile
@@ -1,5 +1,8 @@
-FROM debian:stretch
+FROM debian:buster
 
+RUN sed -i 's/main/main contrib/' /etc/apt/sources.list
+
+RUN echo 'deb http://deb.debian.org/debian buster-backports main contrib\n' >> /etc/apt/sources.list
 
 # Essentials
 RUN apt-get update && apt-get install -y gawk wget git-core diffstat unzip texinfo gcc-multilib build-essential chrpath socat cpio python python3 python3-pip python3-pexpect xz-utils debianutils iputils-ping libsdl1.2-dev xterm
@@ -14,6 +17,9 @@ RUN apt-get update && apt-get install -y qemu-kvm ovmf
 RUN apt-get update && apt-get install -y util-linux btrfs-progs gdisk parted
 
 RUN apt-get update && apt-get install -y screen locales ca-certificates gosu locales
+
+RUN apt-get -y install -t buster-backports repo
+
 RUN dpkg-reconfigure locales
 RUN echo "LC_ALL=en_US.UTF-8" >> /etc/environment
 RUN echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen
@@ -29,10 +35,17 @@ RUN curl -sL https://deb.nodesource.com/setup_11.x | bash - \
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
 RUN echo "deb http://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
 	&& apt-get update \
-	&& apt-get install -y vim openjdk-8-jdk-headless openjdk-8-jre-headless yarn
+	&& apt-get install -y vim openjdk-11-jdk-headless openjdk-11-jre-headless yarn
 
 # optee python dependings
 RUN apt-get update && apt-get install -y python-crypto python3-crypto
+
+RUN mkdir -p /home/builder && echo '[user]\n\
+	name = "builder"\n\
+	email = "builder@builder.com"\n' > /home/builder/.gitconfig
+
+ARG BUILDUSER
+RUN if ! [ -z "${BUILDUSER}" ];then echo "Preparing container home directory for user ${BUILDUSER}" && chown -R ${BUILDUSER}:${BUILDUSER} /home/builder ;fi
 
 WORKDIR "/opt/ws-yocto/"
 

--- a/yocto/docker/run-docker.sh
+++ b/yocto/docker/run-docker.sh
@@ -6,8 +6,16 @@ if [ ! "$1" ]; then
 	exit
 fi
 
+EXTRA_ARGS=""
+
+if [ "$2" ];then
+	echo "Mapping ssh-agent to container"
+	EXTRA_ARGS="--volume $2:/tmp/sshagent --env=SSH_AUTH_SOCK=/tmp/sshagent"
+fi
+
 docker run \
  -it \
+${EXTRA_ARGS} \
  -e LOCAL_USER_ID=`id -u $USER` \
  -v "$1"/:/opt/ws-yocto/ \
  trustx-builder \


### PR DESCRIPTION
Current Linux distributions have versions of repotool
older than 2 in their repositories.
Those versions do not work properly with the current zeus build.

Therefore, this commit updates the Dockerfile to Debian Buster
and installs a current version of repotool from buster-backports.

Also, the follwing changes have been made:
	- Installation of a current JDK (11) available in Debian Buster
	- Ensure usage of Python 2.7 for repo tool to work properly
	- Create home directory for user 'builder'
	- Add Dockerfile argument to pass user ID to be used
	- Added argument to run-docker.sh to map ssh-agent socket to container

Signed-off-by: Felix Wruck <felix.wruck@aisec.fraunhofer.de>