### PR TITLE
Migrate {guestos,container}_config_creator to python3

### DIFF
--- a/device_provisioning/oss_enrollment/config_creator/container_config_creator.py
+++ b/device_provisioning/oss_enrollment/config_creator/container_config_creator.py
@@ -60,8 +60,8 @@ container.guestos_version = int(args.guestos_version)
 container.image_sizes.add(image_name = "data", image_size = int(args.def_size))
 
 try:
-    with open(args.path_to_new_config, "wb") as f:
+    with open(args.path_to_new_config, "w") as f:
         f.write(text_format.MessageToString(container))
 except IOError:
-    print sys.argv[1] + ": Could not open new config file for writing. Aborting."
+    print(sys.argv[1] + ": Could not open new config file for writing. Aborting.")
     sys.exit()

--- a/device_provisioning/oss_enrollment/config_creator/guestos_config_creator.py
+++ b/device_provisioning/oss_enrollment/config_creator/guestos_config_creator.py
@@ -66,7 +66,7 @@ try:
     with open(args.path_to_basic_config, "rb") as f:
         text_format.Merge(f.read(), guestos)
 except IOError:
-    print sys.argv[1] + ": Could not open config file. Aborting."
+    print(sys.argv[1] + ": Could not open config file. Aborting.")
     sys.exit()
 
 guestos.build_date = strftime("%Y-%m-%dT%H:%M:%S%Z")
@@ -101,8 +101,8 @@ set_mounts_hashes( guestos.mounts )
 set_mounts_hashes( guestos.mounts_setup )
 
 try:
-    with open(args.path_to_new_config, "wb") as f:
+    with open(args.path_to_new_config, "w") as f:
         f.write(text_format.MessageToString(guestos))
 except IOError:
-    print sys.argv[1] + ": Could not open new config file for writing. Aborting."
+    print(sys.argv[1] + ": Could not open new config file for writing. Aborting.")
     sys.exit()


### PR DESCRIPTION
As Python2 is EOL and does not receive security updates anymore
migrate the config creator scripts to python3.