### PR TITLE
yocto/init_ws: provide proper config for release and development builds

### DIFF
--- a/yocto/generic/local.conf
+++ b/yocto/generic/local.conf
@@ -1,2 +1,17 @@
+USER_CLASSES ?= "buildstats image-mklibs image-prelink"
 
+PATCHRESOLVE = "noop"
+
+BB_DISKMON_DIRS ??= "\
+    STOPTASKS,${TMPDIR},1G,100K \
+    STOPTASKS,${DL_DIR},1G,100K \
+    STOPTASKS,${SSTATE_DIR},1G,100K \
+    STOPTASKS,/tmp,100M,100K \
+    ABORT,${TMPDIR},100M,1K \
+    ABORT,${DL_DIR},100M,1K \
+    ABORT,${SSTATE_DIR},100M,1K \
+    ABORT,/tmp,10M,1K"
+
+PACKAGECONFIG_append_pn-qemu-native = " sdl"
+PACKAGECONFIG_append_pn-nativesdk-qemu = " sdl"
 PACKAGECONFIG_pn-btrfs-tools = ""

--- a/yocto/init_ws_ids.sh
+++ b/yocto/init_ws_ids.sh
@@ -58,6 +58,17 @@ echo "METAS: ${METAS}"
 SKIP_CONFIG=0
 if [ -d ${BUILD_DIR}/conf ]; then
 	SKIP_CONFIG=1
+else
+	mkdir ${BUILD_DIR}/conf
+	if [ "${DEVELOPMENT_BUILD}" == "n" ]; then
+		# create empty conf without debug-tweeks
+		echo "#PRODUCTION IMAGE" > ${BUILD_DIR}/conf/local.conf
+		echo "DEVELOPMENT_BUILD = \"n\"" >> ${BUILD_DIR}/conf/local.conf
+	else
+		echo "#DEVELOPMENT IMAGE" > ${BUILD_DIR}/conf/local.conf
+		echo "DEVELOPMENT_BUILD = \"y\"" >> ${BUILD_DIR}/conf/local.conf
+		echo "EXTRA_IMAGE_FEATURES = \"debug-tweaks\"" >> ${BUILD_DIR}/conf/local.conf
+	fi
 fi
 
 source ${SRC_DIR}/poky/oe-init-build-env ${BUILD_DIR}
@@ -125,3 +136,13 @@ fi
 
 
 do_link_devrepo
+
+echo ""
+echo "--------------------------------------------"
+echo "[\${DEVELOPMENT_BUILD} = '${DEVELOPMENT_BUILD}']"
+if [ "${DEVELOPMENT_BUILD}" == "n" ]; then
+	echo "### RELEASE_BUILD ###"
+else
+	echo "### DEVELOPMENT_BUILD ###"
+fi
+echo "--------------------------------------------"


### PR DESCRIPTION
Depending on the Environment variable DEVELOMENT_BUILD=n release
build local.conf is generated without debug-tweaks enabled.
Otherwise, debugs-teaks is set in local.conf which is used in meta-trustx
repo to enable debug shells on a virtual as well as serial console.

Signed-off-by: Michael Weiß <michael.weiss@aisec.fraunhofer.de>