### PR TITLE
init_ws_ids.sh: Create non-existent conf parent directory

### DIFF
--- a/yocto/init_ws_ids.sh
+++ b/yocto/init_ws_ids.sh
@@ -59,7 +59,7 @@ SKIP_CONFIG=0
 if [ -d ${BUILD_DIR}/conf ]; then
 	SKIP_CONFIG=1
 else
-	mkdir ${BUILD_DIR}/conf
+	mkdir -p ${BUILD_DIR}/conf
 	if [ "${DEVELOPMENT_BUILD}" == "n" ]; then
 		# create empty conf without debug-tweeks
 		echo "#PRODUCTION IMAGE" > ${BUILD_DIR}/conf/local.conf


### PR DESCRIPTION
Currently, the build fails if the parent directory of 'conf' is missing.
This commit therefore adds the -p option to the mkdir commands.

Signed-off-by: Felix Wruck <felix.wruck@aisec.fraunhofer.de>