### PR TITLE
Guestos remove unsupported features

### DIFF
--- a/config_overlay/arm/debos.conf
+++ b/config_overlay/arm/debos.conf
@@ -24,5 +24,3 @@ mounts {
 description {
 	en: "gnu/debian userland (arm)"
 }
-feature_bg_booting: true
-feature_devtmpfs: true

--- a/config_overlay/arm/device.conf
+++ b/config_overlay/arm/device.conf
@@ -1,7 +1,5 @@
 uuid: "00000000-0000-0000-0000-000000000000"
-mdm_node: "127.0.0.1"
-mdm_service: "8888"
-update_base_url: "http://127.0.0.1:8000/trustme"
+update_base_url: "file://tmp/00000000-0000-0000-0000-000000000000/var/cml-updates"
 c0os: "trustx-coreos"
 host_addr: "10.0.2.15"
 host_subnet: 24

--- a/config_overlay/arm/docker-convertos.conf
+++ b/config_overlay/arm/docker-convertos.conf
@@ -25,6 +25,4 @@ mounts {
 description {
 	en: "docker converter (arm)"
 }
-feature_bg_booting: true
-feature_devtmpfs: true
 feature_install_guest: true

--- a/config_overlay/arm/idsos.conf
+++ b/config_overlay/arm/idsos.conf
@@ -37,5 +37,3 @@ mounts {
 description {
 	en: "ids (yocto-based) userland (arm)"
 }
-feature_bg_booting: true
-feature_devtmpfs: true

--- a/config_overlay/arm/trustx-coreos.conf
+++ b/config_overlay/arm/trustx-coreos.conf
@@ -25,6 +25,3 @@ mounts {
 description {
 	en: "yocoto based core userland (arm)"
 }
-feature_bg_booting: true
-feature_devtmpfs: true
-feature_vpn: true

--- a/config_overlay/x86/debos.conf
+++ b/config_overlay/x86/debos.conf
@@ -24,5 +24,3 @@ mounts {
 description {
 	en: "gnu/debian userland (x86)"
 }
-feature_bg_booting: true
-feature_devtmpfs: true

--- a/config_overlay/x86/device.conf
+++ b/config_overlay/x86/device.conf
@@ -1,7 +1,5 @@
 uuid: "00000000-0000-0000-0000-000000000000"
-mdm_node: "127.0.0.1"
-mdm_service: "8888"
-update_base_url: "http://127.0.0.1:8000/trustme"
+update_base_url: "file://tmp/00000000-0000-0000-0000-000000000000/var/cml-updates"
 host_addr: "10.0.2.15"
 host_subnet: 24
 host_if: "eth0"

--- a/config_overlay/x86/docker-convertos.conf
+++ b/config_overlay/x86/docker-convertos.conf
@@ -32,6 +32,4 @@ mounts {
 description {
 	en: "docker converter (x86)"
 }
-feature_bg_booting: true
-feature_devtmpfs: true
 feature_install_guest: true

--- a/config_overlay/x86/idsos.conf
+++ b/config_overlay/x86/idsos.conf
@@ -37,5 +37,3 @@ mounts {
 description {
 	en: "ids (yocto-based) userland (x86)"
 }
-feature_bg_booting: true
-feature_devtmpfs: true

--- a/config_overlay/x86/kernel.conf
+++ b/config_overlay/x86/kernel.conf
@@ -22,4 +22,3 @@ mounts {
 description {
 	en: "fake OS for kernel update (x86)"
 }
-feature_vpn: true

--- a/config_overlay/x86/trustx-coreos.conf
+++ b/config_overlay/x86/trustx-coreos.conf
@@ -26,6 +26,3 @@ mounts {
 description {
 	en: "yocoto based core userland (x86)"
 }
-feature_bg_booting: true
-feature_devtmpfs: true
-feature_vpn: true


### PR DESCRIPTION
Current cleanup of the cml source repo removes several features mapped
to protobuf config options features_*. Thus, we also remove those
features from the *.conf files here.