### PR TITLE
init_ws_ids: Add flag to enable CC_MODE

### DIFF
--- a/yocto/init_ws_ids.sh
+++ b/yocto/init_ws_ids.sh
@@ -69,6 +69,11 @@ else
 		echo "DEVELOPMENT_BUILD = \"y\"" >> ${BUILD_DIR}/conf/local.conf
 		echo "EXTRA_IMAGE_FEATURES = \"debug-tweaks\"" >> ${BUILD_DIR}/conf/local.conf
 	fi
+
+	if [ "${CC_MODE}" == "y" ]; then
+		echo "CC_MODE = \"y\"" >> ${BUILD_DIR}/conf/local.conf
+	else
+		echo "CC_MODE = \"n\"" >> ${BUILD_DIR}/conf/local.conf
 fi
 
 source ${SRC_DIR}/poky/oe-init-build-env ${BUILD_DIR}


### PR DESCRIPTION
This commit adds support for a CC_MODE environment variable to init_ws_ids.sh
to enable builds with the cmld's CC_MODE enabled.

Signed-off-by: Felix Wruck <felix.wruck@aisec.fraunhofer.de>