### PR TITLE
config_overlay/arm: Enable netns in c0 default conf

### DIFF
--- a/config_overlay/arm/00000000-0000-0000-0000-000000000000.conf
+++ b/config_overlay/arm/00000000-0000-0000-0000-000000000000.conf
@@ -1,5 +1,4 @@
 name: "core0"
 guest_os: "trustx-coreos"
 guestos_version: 1
-netns: false
 assign_dev: "c 4:1 rwm"


### PR DESCRIPTION
Previous versions of c0 shared the netns with the CML layer.
Since userns are enabled by default, this would not work anymore
if only the userns is unshared. Thus, we enable netns as default, too.
For x86 this was already merged.

Signed-off-by: Michael Weiß <michael.weiss@aisec.fraunhofer.de>