### PR TITLE
PKI: Switch to RSA-PSS Padding Scheme

### DIFF
--- a/device_provisioning/gen_dev_certs.sh
+++ b/device_provisioning/gen_dev_certs.sh
@@ -36,7 +36,7 @@ else
 fi
 
 if [ -d ${OUT_CERTS_DIR} ]; then
-	echo "Test Certificates allready generated!"
+	echo "Test Certificates already generated!"
 	exit 0
 fi
 mkdir ${OUT_CERTS_DIR}

--- a/device_provisioning/gen_dev_certs.sh
+++ b/device_provisioning/gen_dev_certs.sh
@@ -22,6 +22,8 @@
 # Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
 #
 
+set -e
+
 SELF="$(cd "$(dirname "$0")" && pwd -P)""/$(basename "$0")"
 
 SELF_DIR="$(dirname ${SELF})"
@@ -52,7 +54,7 @@ fi
 
 
 # copy generated test certificate and keys to out dir
-for i in cert key pk8 x509.pem esl crt auth; do
+for i in cert key esl crt auth; do
 	mv ${CERTS_DIR}/*.${i} ${OUT_CERTS_DIR}
 done
 

--- a/device_provisioning/oss_enrollment/certificates/certificate_configs/openssl-ssig-cml.cnf
+++ b/device_provisioning/oss_enrollment/certificates/certificate_configs/openssl-ssig-cml.cnf
@@ -1,0 +1,32 @@
+HOME            = .
+RANDFILE        = $ENV::HOME/.rnd
+
+####################################################################
+[ req ]
+default_bits        = 4096
+default_keyfile     = ssig_cml.key
+distinguished_name  = user_distinguished_name
+req_extensions      = user_req_extensions
+string_mask         = utf8only
+
+####################################################################
+[ user_distinguished_name ]
+countryName         = Country Name (2 letter code)
+countryName_default     = DE
+
+organizationName         = Organization Name (eg, company)
+organizationName_default    = OSS Release
+
+organizationalUnitName	= Organizational Unit Name (department, division)
+organizationalUnitName_default 	= Development
+
+commonName          = Common Name (e.g. server FQDN or YOUR name)
+commonName_default      = trustme CML Signing Certificate
+
+####################################################################
+[ user_req_extensions ]
+subjectKeyIdentifier=hash
+basicConstraints = critical, CA:FALSE
+keyUsage = critical, nonRepudiation, digitalSignature, keyEncipherment
+authorityInfoAccess=caIssuers;URI:http://localhost/ssig-dummy.cer,OCSP;URI:http://localhost/ssig-dummy-ocsp
+crlDistributionPoints=URI:http://localhost/ssig-dummy.crl

--- a/device_provisioning/oss_enrollment/certificates/certificate_configs/openssl-ssig-subca-cml.cnf
+++ b/device_provisioning/oss_enrollment/certificates/certificate_configs/openssl-ssig-subca-cml.cnf
@@ -1,0 +1,78 @@
+HOME            = .
+RANDFILE        = $ENV::HOME/.rnd
+
+####################################################################
+[ ca ]
+default_ca  = CA_default        # The default ca section
+
+[ CA_default ]
+
+default_days    = 1095          # how long to certify for
+default_md  = sha256       # use public key default MD
+preserve    = no            # keep passed DN ordering
+
+x509_extensions = ca_extensions     # The extensions to add to the cert
+
+email_in_dn = no            # Don't concat the email in the DN
+copy_extensions = copy          # Required to copy SANs from CSR to cert
+
+base_dir    = .
+certificate = $base_dir/ssig_subca_cml.cert  # The CA certifcate
+private_key = $base_dir/ssig_subca_cml.key   # The CA private key
+new_certs_dir   = $base_dir     # Location for new certs after signing
+database    = $base_dir/ssig_subca_cml_index.txt   # Database index file
+serial      = $base_dir/ssig_subca_cml_serial.txt  # The current serial number
+
+unique_subject  = no            # Set to 'no' to allow creation of
+                # several certificates with same subject.
+
+####################################################################
+[ req ]
+default_bits        = 4096
+default_keyfile     = ssig_subca_cml.key
+distinguished_name  = ca_distinguished_name
+req_extensions     = ca_extensions
+string_mask         = utf8only
+
+####################################################################
+[ ca_distinguished_name ]
+countryName         = Country Name (2 letter code)
+countryName_default     = DE
+
+organizationName         = Organization Name (eg, company)
+organizationName_default    = OSS Release
+
+organizationalUnitName		= Organizational Unit Name (eg, section)
+organizationalUnitName_default	= Development
+
+commonName          = Common Name (e.g. server FQDN or YOUR name)
+commonName_default      = trustme CML Signing Sub CA
+
+####################################################################
+[ ca_extensions ]
+
+subjectKeyIdentifier=hash
+#authorityKeyIdentifier=keyid:always, issuer:always
+basicConstraints = critical, CA:true
+keyUsage = critical, keyCertSign, cRLSign
+authorityInfoAccess=caIssuers;URI:http://localhost/ssig-dummy.cer,OCSP;URI:http://localhost/ssig-dummy-ocsp
+crlDistributionPoints=URI:http://localhost/ssig-dummy.crl
+
+####################################################################
+[ signing_policy ]
+countryName     = supplied
+stateOrProvinceName = optional
+localityName        = optional
+organizationName    = supplied
+organizationalUnitName  = supplied
+commonName      = supplied
+emailAddress = optional
+
+####################################################################
+[ signing_req ]
+subjectKeyIdentifier=hash
+authorityKeyIdentifier=keyid:always, issuer:always
+basicConstraints = critical, CA:FALSE
+keyUsage = critical, nonRepudiation, digitalSignature, keyEncipherment
+authorityInfoAccess=caIssuers;URI:http://localhost/ssig-dummy.cer,OCSP;URI:http://localhost/ssig-dummy-ocsp
+crlDistributionPoints=URI:http://localhost/ssig-dummy.crl

--- a/device_provisioning/oss_enrollment/certificates/gen_ocsp_certs.sh
+++ b/device_provisioning/oss_enrollment/certificates/gen_ocsp_certs.sh
@@ -98,7 +98,7 @@ check_clean
 
 # BACKEND CERT
 echo "Create Backend CSR"
-openssl req -batch -config ${OCSP_SERVER_CONFIG} -newkey rsa:${KEY_SIZE} ${PASS_IN} ${PASS_OUT} -out ${OCSP_SERVER_CSR} -outform PEM -nodes
+openssl req -batch -config ${OCSP_SERVER_CONFIG} -newkey rsa-pss -pkeyopt rsa_keygen_bits:${KEY_SIZE} ${PASS_IN} ${PASS_OUT} -out ${OCSP_SERVER_CSR} -outform PEM -nodes
 error_check $? "Failed to create OCSP Server CSR"
 
 echo "Sign OCSP Server CSR with backend sub CA certificate"

--- a/device_provisioning/oss_enrollment/certificates/gen_pki_backend_certs.sh
+++ b/device_provisioning/oss_enrollment/certificates/gen_pki_backend_certs.sh
@@ -109,7 +109,7 @@ check_clean
 
 # BACKEND SUB CA CERT
 echo "Create backend sub CA CSR"
-openssl req -batch -config ${BACKEND_SUBCA_CONFIG} -newkey rsa:${KEY_SIZE} ${PASS_IN} ${PASS_OUT} -out ${BACKEND_SUBCA_CSR} -outform PEM
+openssl req -batch -config ${BACKEND_SUBCA_CONFIG} -newkey rsa-pss -pkeyopt rsa_keygen_bits:${KEY_SIZE} ${PASS_IN} ${PASS_OUT} -out ${BACKEND_SUBCA_CSR} -outform PEM
 error_check $? "Failed to create backend sub CA CSR"
 
 echo "Sign backend sub CA CSR with general root CA"
@@ -125,7 +125,7 @@ cat ${GEN_ROOTCA_CERT} >> ${BACKEND_SUBCA_CERT}
 
 # BACKEND CERT
 echo "Create Backend CSR"
-openssl req -batch -config ${BACKEND_CONFIG} -newkey rsa:${KEY_SIZE} ${PASS_IN} ${PASS_OUT} -out ${BACKEND_CSR} -outform PEM -nodes
+openssl req -batch -config ${BACKEND_CONFIG} -newkey rsa-pss -pkeyopt rsa_keygen_bits:${KEY_SIZE} ${PASS_IN} ${PASS_OUT} -out ${BACKEND_CSR} -outform PEM -nodes
 error_check $? "Failed to create Backend CSR"
 
 echo "Sign Backend CSR with backend sub CA certificate"

--- a/device_provisioning/oss_enrollment/certificates/gen_pki_generator.sh
+++ b/device_provisioning/oss_enrollment/certificates/gen_pki_generator.sh
@@ -128,12 +128,12 @@ check_clean
 ## Create CA mode ##
 # GEN ROOT CA CERT
 echo "Create self-signed general root CA certificate"
-openssl req -batch -x509 -config ${GEN_ROOTCA_CONFIG} -days ${DAYS_VALID} -newkey rsa:${KEY_SIZE} ${PASS_IN} ${PASS_OUT} -out ${GEN_ROOTCA_CERT} -outform PEM
+openssl req -batch -x509 -config ${GEN_ROOTCA_CONFIG} -days ${DAYS_VALID} -newkey rsa-pss -pkeyopt rsa_keygen_bits:${KEY_SIZE} ${PASS_IN} ${PASS_OUT} -out ${GEN_ROOTCA_CERT} -outform PEM
 error_check $? "Failed to create self signed general root CA certificate"
 
 # DEVICE SUB CA CERT
 echo "Create device sub CA CSR"
-openssl req -batch -config ${DEVICE_SUBCA_CONFIG} -newkey rsa:${KEY_SIZE} ${PASS_IN} ${PASS_OUT} -out ${DEVICE_SUBCA_CSR} -outform PEM
+openssl req -batch -config ${DEVICE_SUBCA_CONFIG} -newkey rsa-pss -pkeyopt rsa_keygen_bits:${KEY_SIZE} ${PASS_IN} ${PASS_OUT} -out ${DEVICE_SUBCA_CSR} -outform PEM
 error_check $? "Failed to create device sub CA CSR"
 
 echo "Sign device sub CA CSR with general root CA"
@@ -150,7 +150,7 @@ cat ${GEN_ROOTCA_CERT} >> ${DEVICE_SUBCA_CERT}
 
 # USER SUB CA CERT
 echo "Create user sub CA CSR"
-openssl req -batch -config ${USER_SUBCA_CONFIG} -newkey rsa:${KEY_SIZE} ${PASS_IN} ${PASS_OUT} -out ${USER_SUBCA_CSR} -outform PEM
+openssl req -batch -config ${USER_SUBCA_CONFIG} -newkey rsa-pss -pkeyopt rsa_keygen_bits:${KEY_SIZE} ${PASS_IN} ${PASS_OUT} -out ${USER_SUBCA_CSR} -outform PEM
 error_check $? "Failed to create user sub CA CSR"
 
 echo "Sign user sub CA CSR with general root CA"

--- a/device_provisioning/oss_enrollment/certificates/gen_pki_generator.sh
+++ b/device_provisioning/oss_enrollment/certificates/gen_pki_generator.sh
@@ -128,7 +128,7 @@ check_clean
 ## Create CA mode ##
 # GEN ROOT CA CERT
 echo "Create self-signed general root CA certificate"
-openssl req -batch -x509 -config ${GEN_ROOTCA_CONFIG} -days ${DAYS_VALID} -newkey rsa-pss -pkeyopt rsa_keygen_bits:${KEY_SIZE} ${PASS_IN} ${PASS_OUT} -out ${GEN_ROOTCA_CERT} -outform PEM
+openssl req -batch -x509 -config ${GEN_ROOTCA_CONFIG} -days ${DAYS_VALID} -newkey rsa:${KEY_SIZE} ${PASS_IN} ${PASS_OUT} -out ${GEN_ROOTCA_CERT} -outform PEM
 error_check $? "Failed to create self signed general root CA certificate"
 
 # DEVICE SUB CA CERT

--- a/device_provisioning/oss_enrollment/certificates/sec_platform_keys.sh
+++ b/device_provisioning/oss_enrollment/certificates/sec_platform_keys.sh
@@ -77,8 +77,8 @@ echo $UUID
 
 for x in PK KEK DB; do
 echo "generate secure boot key=${x}"
-	echo "cmd=\"openssl req -new -x509 -sha256 -newkey rsa-pss -pkeyopt rsa_keygen_bits:${KEY_SIZE} -keyout ${x}.key -out ${x}.crt -days ${CERT_DAYS} -subj "${SUBJ}CN=${x}" -nodes\""
-	openssl req -new -x509 -sha256 -newkey rsa-pss -pkeyopt rsa_keygen_bits:${KEY_SIZE} -subj "${SUBJ}CN=${x}/" -keyout ${x}.key -out ${x}.crt -days ${CERT_DAYS} -nodes
+	echo "cmd=\"openssl req -new -x509 -sha256 -newkey rsa:${KEY_SIZE} -keyout ${x}.key -out ${x}.crt -days ${CERT_DAYS} -subj "${SUBJ}CN=${x}" -nodes\""
+	openssl req -new -x509 -sha256 -newkey rsa:${KEY_SIZE} -subj "${SUBJ}CN=${x}/" -keyout ${x}.key -out ${x}.crt -days ${CERT_DAYS} -nodes
 	cert-to-efi-sig-list -g $UUID ${x}.crt ${x}.esl
 done
 

--- a/device_provisioning/oss_enrollment/certificates/sec_platform_keys.sh
+++ b/device_provisioning/oss_enrollment/certificates/sec_platform_keys.sh
@@ -77,8 +77,8 @@ echo $UUID
 
 for x in PK KEK DB; do
 echo "generate secure boot key=${x}"
-	echo "cmd=\"openssl req -new -x509 -sha256 -newkey rsa:${KEY_SIZE} -keyout ${x}.key -out ${x}.crt -days ${CERT_DAYS} -subj "${SUBJ}CN=${x}" -nodes\""
-	openssl req -new -x509 -sha256 -newkey rsa:${KEY_SIZE} -subj "${SUBJ}CN=${x}/" -keyout ${x}.key -out ${x}.crt -days ${CERT_DAYS} -nodes
+	echo "cmd=\"openssl req -new -x509 -sha256 -newkey rsa-pss -pkeyopt rsa_keygen_bits:${KEY_SIZE} -keyout ${x}.key -out ${x}.crt -days ${CERT_DAYS} -subj "${SUBJ}CN=${x}" -nodes\""
+	openssl req -new -x509 -sha256 -newkey rsa-pss -pkeyopt rsa_keygen_bits:${KEY_SIZE} -subj "${SUBJ}CN=${x}/" -keyout ${x}.key -out ${x}.crt -days ${CERT_DAYS} -nodes
 	cert-to-efi-sig-list -g $UUID ${x}.crt ${x}.esl
 done
 

--- a/device_provisioning/oss_enrollment/certificates/ssig_aosp_release_keys.sh
+++ b/device_provisioning/oss_enrollment/certificates/ssig_aosp_release_keys.sh
@@ -88,8 +88,8 @@ AOSP_CERT_DAYS=2190
 
 echo "Concatenate aosp release keys"
 for x in releasekey platform shared media; do
-	#openssl req -new -x509 -sha256 -newkey rsa:${KEY_SIZE} -out ${x}.x509.pem -days 10000 -subj "${AOSP_SUBJ}CN=${x}"
-	openssl req -batch -sha256 -newkey rsa:${KEY_SIZE} ${PASS_IN} -out ${x}.x509.csr -keyout ${x}.key -outform PEM -days ${AOSP_CERT_DAYS} -subj "${AOSP_SUBJ}CN=${x}" -nodes
+	#openssl req -new -x509 -sha256 -newkey rsa-pss -pkeyopt rsa_keygen_bits:${KEY_SIZE} -out ${x}.x509.pem -days 10000 -subj "${AOSP_SUBJ}CN=${x}"
+	openssl req -batch -sha256 -newkey rsa-pss -pkeyopt rsa_keygen_bits:${KEY_SIZE} ${PASS_IN} -out ${x}.x509.csr -keyout ${x}.key -outform PEM -days ${AOSP_CERT_DAYS} -subj "${AOSP_SUBJ}CN=${x}" -nodes
 	echo "Sign ${x} AOSP CSR with ssig sub CA certificate"
 	openssl ca -create_serial -batch -config ${SSIG_SUBCA_CONFIG} -days ${AOSP_CERT_DAYS} -policy signing_policy -extensions signing_req ${PASS_IN} -out ${x}.x509.pem -infiles ${x}.x509.csr
 	error_check $? "Failed to sign $x AOSP CSR with ssig sub CA certificate"

--- a/device_provisioning/oss_enrollment/certificates/ssig_pki_generator.conf
+++ b/device_provisioning/oss_enrollment/certificates/ssig_pki_generator.conf
@@ -13,6 +13,7 @@ SSIG_ROOTCA_CERT="ssig_rootca.cert"
 #ssig root CA key file
 SSIG_ROOTCA_KEY="ssig_rootca.key"
 
+## sub CA (kernel)
 #ssig sub CA sign index file
 SSIG_SUBCA_INDEX_FILE="ssig_subca_index.txt"
 #ssig sub CA sign serial file
@@ -26,11 +27,33 @@ SSIG_SUBCA_CERT="ssig_subca.cert"
 #ssig sub CA key file
 SSIG_SUBCA_KEY="ssig_subca.key"
 
-#SSIG certificate files
+## sub CA (CML)
+#ssig sub CA sign index file
+SSIG_SUBCA_CML_INDEX_FILE="ssig_subca_cml_index.txt"
+#ssig sub CA sign serial file
+SSIG_SUBCA_CML_SERIAL_FILE="ssig_subca_cml_serial.txt"
+#ssig sub CA config file
+SSIG_SUBCA_CML_CONFIG="certificate_configs/openssl-ssig-subca-cml.cnf"
+#ssig sub CA csr file
+SSIG_SUBCA_CML_CSR="ssig_subca_cml.csr"
+#ssig sub CA cert file
+SSIG_SUBCA_CML_CERT="ssig_subca_cml.cert"
+#ssig sub CA key file
+SSIG_SUBCA_CML_KEY="ssig_subca_cml.key"
+
+
+#SSIG (kernel) certificate files
 SSIG_CONFIG="certificate_configs/openssl-ssig.cnf"
 SSIG_CSR="ssig.csr"
 SSIG_CERT="ssig.cert"
 SSIG_KEY="ssig.key"
+
+#SSIG (CML) certificate files
+SSIG_CML_CONFIG="certificate_configs/openssl-ssig-cml.cnf"
+SSIG_CML_CSR="ssig_cml.csr"
+SSIG_CML_CERT="ssig_cml.cert"
+SSIG_CML_KEY="ssig_cml.key"
+
 
 #cert key size
 KEY_SIZE="4096"

--- a/device_provisioning/oss_enrollment/certificates/ssig_pki_generator.sh
+++ b/device_provisioning/oss_enrollment/certificates/ssig_pki_generator.sh
@@ -138,20 +138,16 @@ cat ${SSIG_ROOTCA_CERT} >> ${SSIG_SUBCA_CERT}
 # SSIG SUB CA (CML) CERT
 echo "Create ssig sub CA (CML) CSR"
 openssl req -batch -config ${SSIG_SUBCA_CML_CONFIG} -newkey rsa-pss -pkeyopt rsa_keygen_bits:${KEY_SIZE} ${PASS_IN} ${PASS_OUT} -out ${SSIG_SUBCA_CML_CSR} -outform PEM
-error_check $? "Failed to create ssig sub CA CSR"
+error_check $? "Failed to create ssig sub CA (CML) CSR"
 
-echo "Sign ssig sub CA CSR with ssig root CA"
+echo "Sign ssig sub CA (CML) CSR with ssig root CA"
 touch ${SSIG_ROOTCA_INDEX_FILE}
 openssl ca -notext -create_serial -batch -config ${SSIG_ROOTCA_CONFIG} -policy signing_policy -extensions signing_req_CA ${PASS_IN} -out ${SSIG_SUBCA_CML_CERT} -infiles ${SSIG_SUBCA_CML_CSR}
-error_check $? "Failed to sign ssig sub CA CSR with ssig root CA certificate"
+error_check $? "Failed to sign ssig sub CA CSR (CML) with ssig root CA certificate"
 
-echo "Verify newly created ssig sub CA certificate"
+echo "Verify newly created ssig sub CA (CML) certificate"
 openssl verify -CAfile ${SSIG_ROOTCA_CERT} ${SSIG_SUBCA_CML_CERT}
 error_check $? "Failed to verify newly signed ssig sub CA (CML) certificate"
-
-#echo "Concatenate ssig root CA cert to ssig subca (CML) cert"
-#cat ${SSIG_ROOTCA_CERT} >> ${SSIG_SUBCA_CML_CERT}
-
 
 
 # SSIG CERT (kernel)
@@ -173,18 +169,18 @@ cat ${SSIG_SUBCA_CERT} >> ${SSIG_CERT}
 
 
 # SSIG CERT (CML)
-echo "Create software signing CSR"
+echo "Create software signing (CML) CSR"
 openssl req -batch -config ${SSIG_CML_CONFIG} -newkey rsa-pss -pkeyopt rsa_keygen_bits:${KEY_SIZE} ${PASS_IN} ${PASS_OUT} -out ${SSIG_CML_CSR} -outform PEM
-error_check $? "Failed to create software signing CSR"
+error_check $? "Failed to create software signing (CML) CSR"
 
-echo "Sign software signing CSR with ssig sub CA certificate"
+echo "Sign software signing CSR with ssig sub CA (CML) certificate"
 touch ${SSIG_SUBCA_CML_INDEX_FILE}
 openssl ca -notext -create_serial -batch -config ${SSIG_SUBCA_CML_CONFIG} -policy signing_policy -extensions signing_req ${PASS_IN} -sigopt rsa_padding_mode:pss -sigopt rsa_pss_saltlen:-1 -out ${SSIG_CML_CERT} -infiles ${SSIG_CML_CSR}
-error_check $? "Failed to sign software signing CSR with ssig sub CA certificate"
+error_check $? "Failed to sign software signing (CML) CSR with ssig sub CA (CML) certificate"
 
-echo "Verify newly created ssig certificate"
+echo "Verify newly created ssig (CML) certificate"
 openssl verify -CAfile ${SSIG_ROOTCA_CERT} -untrusted ${SSIG_SUBCA_CML_CERT} ${SSIG_CML_CERT}
-error_check $? "Failed to verify newly signed ssig certificate"
+error_check $? "Failed to verify newly signed (CML) ssig certificate"
 
 echo "Concatenate ssig CA chain to ssig cert"
 cat ${SSIG_SUBCA_CML_CERT} >> ${SSIG_CML_CERT}

--- a/device_provisioning/oss_enrollment/certificates/ssig_pki_generator.sh
+++ b/device_provisioning/oss_enrollment/certificates/ssig_pki_generator.sh
@@ -120,7 +120,7 @@ error_check $? "Failed to create ssig sub CA CSR"
 
 echo "Sign ssig sub CA CSR with ssig root CA"
 touch ${SSIG_ROOTCA_INDEX_FILE}
-openssl ca -create_serial -batch -config ${SSIG_ROOTCA_CONFIG} -policy signing_policy -extensions signing_req_CA ${PASS_IN} -out ${SSIG_SUBCA_CERT} -infiles ${SSIG_SUBCA_CSR}
+openssl ca -notext -create_serial -batch -config ${SSIG_ROOTCA_CONFIG} -policy signing_policy -extensions signing_req_CA ${PASS_IN} -out ${SSIG_SUBCA_CERT} -infiles ${SSIG_SUBCA_CSR}
 error_check $? "Failed to sign ssig sub CA CSR with ssig root CA certificate"
 
 echo "Verify newly created ssig sub CA certificate"
@@ -137,7 +137,7 @@ error_check $? "Failed to create software signing CSR"
 
 echo "Sign software signing CSR with ssig sub CA certificate"
 touch ${SSIG_SUBCA_INDEX_FILE}
-openssl ca -create_serial -batch -config ${SSIG_SUBCA_CONFIG} -policy signing_policy -extensions signing_req ${PASS_IN} -out ${SSIG_CERT} -infiles ${SSIG_CSR}
+openssl ca -notext -create_serial -batch -config ${SSIG_SUBCA_CONFIG} -policy signing_policy -extensions signing_req ${PASS_IN} -out ${SSIG_CERT} -infiles ${SSIG_CSR}
 error_check $? "Failed to sign software signing CSR with ssig sub CA certificate"
 
 echo "Verify newly created ssig certificate"

--- a/device_provisioning/oss_enrollment/certificates/ssig_pki_generator.sh
+++ b/device_provisioning/oss_enrollment/certificates/ssig_pki_generator.sh
@@ -110,12 +110,12 @@ check_clean
 
 # SSIG ROOT CA CERT
 echo "Create self-signed ssig root CA certificate"
-openssl req -batch -x509 -config ${SSIG_ROOTCA_CONFIG} -newkey rsa:${KEY_SIZE} -days ${DAYS_VALID} ${PASS_IN} ${PASS_OUT} -out ${SSIG_ROOTCA_CERT} -outform PEM
+openssl req -batch -x509 -config ${SSIG_ROOTCA_CONFIG} -newkey rsa-pss -pkeyopt rsa_keygen_bits:${KEY_SIZE} -days ${DAYS_VALID} ${PASS_IN} ${PASS_OUT} -out ${SSIG_ROOTCA_CERT} -outform PEM
 error_check $? "Failed to create self signed ssig root CA certificate"
 
 # SSIG SUB CA CERT
 echo "Create ssig sub CA CSR"
-openssl req -batch -config ${SSIG_SUBCA_CONFIG} -newkey rsa:${KEY_SIZE} ${PASS_IN} ${PASS_OUT} -out ${SSIG_SUBCA_CSR} -outform PEM
+openssl req -batch -config ${SSIG_SUBCA_CONFIG} -newkey rsa-pss -pkeyopt rsa_keygen_bits:${KEY_SIZE} ${PASS_IN} ${PASS_OUT} -out ${SSIG_SUBCA_CSR} -outform PEM
 error_check $? "Failed to create ssig sub CA CSR"
 
 echo "Sign ssig sub CA CSR with ssig root CA"
@@ -132,7 +132,7 @@ cat ${SSIG_ROOTCA_CERT} >> ${SSIG_SUBCA_CERT}
 
 # SSIG CERT
 echo "Create software signing CSR"
-openssl req -batch -config ${SSIG_CONFIG} -newkey rsa:${KEY_SIZE} ${PASS_IN} ${PASS_OUT} -out ${SSIG_CSR} -outform PEM
+openssl req -batch -config ${SSIG_CONFIG} -newkey rsa-pss -pkeyopt rsa_keygen_bits:${KEY_SIZE} ${PASS_IN} ${PASS_OUT} -out ${SSIG_CSR} -outform PEM
 error_check $? "Failed to create software signing CSR"
 
 echo "Sign software signing CSR with ssig sub CA certificate"

--- a/device_provisioning/oss_enrollment/certificates/usertoken_generator.sh
+++ b/device_provisioning/oss_enrollment/certificates/usertoken_generator.sh
@@ -127,7 +127,7 @@ if [ "${USER_TOKEN_CN}" != "" ]; then
 
   echo "Create new user CSR"
   # pwd is set when creating p12 token, so -nodes should be fine here
-  openssl req -nodes -batch -config ${USER_CONFIG} -newkey rsa:${KEY_SIZE} ${PASS_IN_CA} -out ${USER_CSR} -outform PEM -subj "/C=DE/O=OSS Release/OU=Development/CN=${USER_TOKEN_CN}/"
+  openssl req -nodes -batch -config ${USER_CONFIG} -newkey rsa-pss -pkeyopt rsa_keygen_bits:${KEY_SIZE} ${PASS_IN_CA} -out ${USER_CSR} -outform PEM -subj "/C=DE/O=OSS Release/OU=Development/CN=${USER_TOKEN_CN}/"
   error_check $? "Failed to create new user CSR"
 
   echo "Sign user CSR with user sub CA certificate"

--- a/device_provisioning/oss_enrollment/config_creator/sign_config.sh
+++ b/device_provisioning/oss_enrollment/config_creator/sign_config.sh
@@ -36,9 +36,9 @@ if [ -z $4 ]
 then
 	source ${SELF_DIR}/../../test_passwd_env.bash
 	PASS_IN_CA="-passin env:TRUSTME_TEST_PASSWD_PKI"
-	openssl dgst -sha512 -sign "$key" -out "$sig" ${PASS_IN_CA} "$cfg"
+	openssl dgst -sha512 -sign "$key" -sigopt rsa_padding_mode:pss -sigopt rsa_pss_saltlen:-1 -out "$sig" ${PASS_IN_CA} "$cfg"
 else
-	openssl dgst -sha512 -sign "$key" -out "$sig" -passin "pass:$4" "$cfg"
+	openssl dgst -sha512 -sign "$key" -sigopt rsa_padding_mode:pss -sigopt rsa_pss_saltlen:-1 -out "$sig" -passin "pass:$4" "$cfg"
 fi
 
 openssl_err=$?


### PR DESCRIPTION
This commit adapts the PKI generation scripts
to use the RSA-PSS padding scheme.
Also, the explicit KEY_SIZE override is removed,
such that the OpenSSL cnf files define the key size.

Signed-off-by: Felix Wruck <felix.wruck@aisec.fraunhofer.de>