### PR TITLE
yocto/install_trustme.sh: fixed label for boot partition

### DIFF
--- a/yocto/install_trustme.sh
+++ b/yocto/install_trustme.sh
@@ -37,7 +37,7 @@ if [ "$FORMAT" = "y" ]; then
 	sync
 	partprobe
 
-	mkfs.fat -F 16 -n BOOT ${OUTFILE}${INFIX}1
+	mkfs.fat -F 16 -n boot ${OUTFILE}${INFIX}1
 	sync
 	sleep 2
 	partprobe


### PR DESCRIPTION
The CML fstab expects the boot partition to be labeled "boot"
and not "BOOT". Thus we changed it here, too.

Signed-off-by: Michael Weiß <michael.weiss@aisec.fraunhofer.de>