### PR TITLE
yocto/*/metas: removed meta-selinux layer

### DIFF
--- a/yocto/arm32/colibri-imx6ull/metas
+++ b/yocto/arm32/colibri-imx6ull/metas
@@ -8,7 +8,6 @@ meta-freescale
 meta-freescale-3rdparty
 meta-freescale-distro
 meta-virtualization
-meta-selinux
 meta-java
 meta-trustx
 meta-trustx-nxp

--- a/yocto/arm32/colibri-imx6ull/metas_ids
+++ b/yocto/arm32/colibri-imx6ull/metas_ids
@@ -8,7 +8,6 @@ meta-freescale
 meta-freescale-3rdparty
 meta-freescale-distro
 meta-virtualization
-meta-selinux
 meta-java
 meta-trustx
 meta-trustx-nxp

--- a/yocto/arm32/nitrogen6x/metas
+++ b/yocto/arm32/nitrogen6x/metas
@@ -8,7 +8,6 @@ meta-freescale
 meta-freescale-3rdparty
 meta-freescale-distro
 meta-virtualization
-meta-selinux
 meta-java
 meta-trustx
 meta-trustx-nxp

--- a/yocto/arm32/nitrogen6x/metas_ids
+++ b/yocto/arm32/nitrogen6x/metas_ids
@@ -8,7 +8,6 @@ meta-freescale
 meta-freescale-3rdparty
 meta-freescale-distro
 meta-virtualization
-meta-selinux
 meta-java
 meta-trustx
 meta-trustx-nxp

--- a/yocto/arm32/raspberrypi2/metas
+++ b/yocto/arm32/raspberrypi2/metas
@@ -6,7 +6,6 @@ meta-openembedded/meta-networking
 meta-openembedded/meta-perl
 meta-openembedded/meta-filesystems
 meta-virtualization
-meta-selinux
 meta-java
 meta-trustx
 meta-trustx-rpi

--- a/yocto/arm32/raspberrypi2/metas_ids
+++ b/yocto/arm32/raspberrypi2/metas_ids
@@ -6,7 +6,6 @@ meta-openembedded/meta-networking
 meta-openembedded/meta-perl
 meta-openembedded/meta-filesystems
 meta-virtualization
-meta-selinux
 meta-java
 meta-trustx
 meta-trustx-rpi

--- a/yocto/arm64/nvidia-jetson/metas
+++ b/yocto/arm64/nvidia-jetson/metas
@@ -2,7 +2,6 @@ poky/meta
 poky/meta-poky 
 poky/meta-yocto-bsp
 meta-tegra
-meta-selinux
 meta-virtualization
 meta-openembedded/meta-oe
 meta-openembedded/meta-initramfs

--- a/yocto/arm64/raspberrypi3-64/metas
+++ b/yocto/arm64/raspberrypi3-64/metas
@@ -6,7 +6,6 @@ meta-openembedded/meta-networking
 meta-openembedded/meta-perl
 meta-openembedded/meta-filesystems
 meta-virtualization
-meta-selinux
 meta-java
 meta-trustx
 meta-trustx-rpi

--- a/yocto/arm64/raspberrypi3-64/metas_ids
+++ b/yocto/arm64/raspberrypi3-64/metas_ids
@@ -6,7 +6,6 @@ meta-openembedded/meta-networking
 meta-openembedded/meta-perl
 meta-openembedded/meta-filesystems
 meta-virtualization
-meta-selinux
 meta-java
 meta-trustx
 meta-trustx-rpi

--- a/yocto/arm64/zcu104-zynqmp/metas
+++ b/yocto/arm64/zcu104-zynqmp/metas
@@ -8,7 +8,6 @@ meta-openembedded/meta-networking
 meta-openembedded/meta-perl
 meta-openembedded/meta-filesystems
 meta-virtualization
-meta-selinux
 meta-java
 meta-trustx
 meta-xilinx-tools

--- a/yocto/arm64/zcu104-zynqmp/metas_ids
+++ b/yocto/arm64/zcu104-zynqmp/metas_ids
@@ -8,7 +8,6 @@ meta-openembedded/meta-networking
 meta-openembedded/meta-perl
 meta-openembedded/meta-filesystems
 meta-virtualization
-meta-selinux
 meta-java
 meta-trustx
 meta-xilinx-tools

--- a/yocto/x86/genericx86-64/metas
+++ b/yocto/x86/genericx86-64/metas
@@ -4,7 +4,6 @@ meta-openembedded/meta-networking
 meta-openembedded/meta-perl
 meta-openembedded/meta-filesystems
 meta-virtualization
-meta-selinux
 meta-java
 meta-trustx
 meta-trustx-intel

--- a/yocto/x86/metas_ids
+++ b/yocto/x86/metas_ids
@@ -5,7 +5,6 @@ meta-openembedded/meta-networking
 meta-openembedded/meta-perl
 meta-openembedded/meta-filesystems
 meta-virtualization
-meta-selinux
 meta-java
 meta-trustx
 meta-trustx-intel


### PR DESCRIPTION
trustme does not depend on selinux anymore. Thus we do not need
the meta-selinux layer anymore and remove it here.

Signed-off-by: Michael Weiß <michael.weiss@aisec.fraunhofer.de>