### PR TITLE
cml_tools/*: Bugfix in the  installation scripts

### DIFF
--- a/cml_tools/Makefile
+++ b/cml_tools/Makefile
@@ -50,20 +50,20 @@ install_ressources:
 
 install_build_script:
 	install -d ${DESTDIR}$(prefix)/bin
-	sed '6s:SCRIPTS_DIR=.*:SCRIPTS_DIR=$(SCRIPTS_DIR):' \
+	sed '0,/SCRIPTS_DIR=.*/s:SCRIPTS_DIR=.*:SCRIPTS_DIR=$(SCRIPTS_DIR):' \
 		<./cml_build_guestos.sh > \
 		$(DESTDIR)$(prefix)/bin/cml_build_guestos
 	chmod +x $(DESTDIR)$(prefix)/bin/cml_build_guestos
 
 install_certs_script:
 	install -d ${DESTDIR}$(prefix)/bin
-	sed '3s:SCRIPTS_DIR=.*:SCRIPTS_DIR=$(SCRIPTS_DIR):' \
+	sed '0,/SCRIPTS_DIR=.*/s:SCRIPTS_DIR=.*:SCRIPTS_DIR=$(SCRIPTS_DIR):' \
 		<./cml_gen_dev_certs_wrapper.sh > $(DESTDIR)$(prefix)/bin/cml_gen_dev_certs
 	chmod +x $(DESTDIR)$(prefix)/bin/cml_gen_dev_certs
 
 install_sign_script:
 	install -d ${DESTDIR}$(prefix)/bin
-	sed 's:INSTALLDIR:$(SCRIPTS_DIR):' \
+	sed '0,/SCRIPTS_DIR=.*/s:SCRIPTS_DIR=.*:SCRIPTS_DIR=$(SCRIPTS_DIR):' \
 		<./cml_sign_config_wrapper.sh > $(DESTDIR)$(prefix)/bin/cml_sign_config
 	chmod +x $(DESTDIR)$(prefix)/bin/cml_sign_config
 

--- a/cml_tools/cml_build_guestos.sh
+++ b/cml_tools/cml_build_guestos.sh
@@ -25,7 +25,13 @@
 set -e
 
 PROGNAME="$(basename "$0")"
-SCRIPTS_DIR="$(readlink -f "..")" # !!! this line will be replaced on installation !!!
+SCRIPTS_DIR=# Path to cml-tools folder (set on installation)
+
+# check if SCRIPTS_DIR is set
+if [[ -z $SCRIPTS_DIR || ! -e $SCRIPTS_DIR/device_provisioning ]]; then
+    echo "Error: SCRIPTS_DIR is not set correctly in the script" >&2
+    exit 1
+fi
 
 # ROOTFS | INIT | SIGNOS
 MODE=""

--- a/cml_tools/cml_gen_dev_certs_wrapper.sh
+++ b/cml_tools/cml_gen_dev_certs_wrapper.sh
@@ -22,7 +22,14 @@
 # Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
 #
 
-SCRIPTS_DIR=#Set on installation
+SCRIPTS_DIR=# Path to cml-tools folder (set on installation)
+
+# check if SCRIPTS_DIR is set
+if [[ -z $SCRIPTS_DIR || ! -e $SCRIPTS_DIR/device_provisioning ]]; then
+    echo "Error: SCRIPTS_DIR is not set correctly in the script" >&2
+    exit 1
+fi
+
 SELF_DIR=$(pwd)
 WORKDIR=${SELF_DIR}/.device_provisioning
 

--- a/cml_tools/cml_sign_config_wrapper.sh
+++ b/cml_tools/cml_sign_config_wrapper.sh
@@ -22,5 +22,13 @@
 # Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
 #
 
-bash INSTALLDIR/device_provisioning/oss_enrollment/config_creator/\
+SCRIPTS_DIR=# Path to cml-tools folder (set on installation)
+
+# check if SCRIPTS_DIR is set
+if [[ -z $SCRIPTS_DIR || ! -e $SCRIPTS_DIR/device_provisioning ]]; then
+    echo "Error: SCRIPTS_DIR is not set correctly in the script" >&2
+    exit 1
+fi
+
+bash ${SCRIPTS_DIR}/device_provisioning/oss_enrollment/config_creator/\
 sign_config.sh "$@"


### PR DESCRIPTION
Fixed a bug which caused that the SCRIPTS_DIR variable was not set correctly
on installation.

* cml_tools/Makefile: the SCRIPTS_DIR variable is now detected more
  reliable by sed
* cml_tools/cml_build_guestos.sh + cml_gen_dev_certs_wrapper.sh +
  cml_sign_config_wrapper.sh: added validation check for  SCRIPTS_DIR variable

Signed-off-by: Maximilian Peisl <maximilian.peisl@aisec.fraunhofer.de>