### PR TITLE
Initial Support for Kirkstone

### DIFF
--- a/yocto/arm32/multiconfig/container.conf
+++ b/yocto/arm32/multiconfig/container.conf
@@ -181,26 +181,6 @@ USER_CLASSES ?= "buildstats image-mklibs image-prelink"
 PATCHRESOLVE = "noop"
 
 #
-# Disk Space Monitoring during the build
-#
-# Monitor the disk space during the build. If there is less that 1GB of space or less
-# than 100K inodes in any key build location (TMPDIR, DL_DIR, SSTATE_DIR), gracefully
-# shutdown the build. If there is less that 100MB or 1K inodes, perform a hard abort
-# of the build. The reason for this is that running completely out of space can corrupt
-# files and damages the build in ways which may not be easily recoverable.
-# It's necesary to monitor /tmp, if there is no space left the build will fail
-# with very exotic errors.
-BB_DISKMON_DIRS ??= "\
-    STOPTASKS,${TMPDIR},1G,100K \
-    STOPTASKS,${DL_DIR},1G,100K \
-    STOPTASKS,${SSTATE_DIR},1G,100K \
-    STOPTASKS,/tmp,100M,100K \
-    ABORT,${TMPDIR},100M,1K \
-    ABORT,${DL_DIR},100M,1K \
-    ABORT,${SSTATE_DIR},100M,1K \
-    ABORT,/tmp,10M,1K"
-
-#
 # Shared-state files from other locations
 #
 # As mentioned above, shared state files are prebuilt cache data objects which can

--- a/yocto/arm32/multiconfig/container_arm32.conf
+++ b/yocto/arm32/multiconfig/container_arm32.conf
@@ -181,26 +181,6 @@ USER_CLASSES ?= "buildstats image-mklibs image-prelink"
 PATCHRESOLVE = "noop"
 
 #
-# Disk Space Monitoring during the build
-#
-# Monitor the disk space during the build. If there is less that 1GB of space or less
-# than 100K inodes in any key build location (TMPDIR, DL_DIR, SSTATE_DIR), gracefully
-# shutdown the build. If there is less that 100MB or 1K inodes, perform a hard abort
-# of the build. The reason for this is that running completely out of space can corrupt
-# files and damages the build in ways which may not be easily recoverable.
-# It's necesary to monitor /tmp, if there is no space left the build will fail
-# with very exotic errors.
-BB_DISKMON_DIRS ??= "\
-    STOPTASKS,${TMPDIR},1G,100K \
-    STOPTASKS,${DL_DIR},1G,100K \
-    STOPTASKS,${SSTATE_DIR},1G,100K \
-    STOPTASKS,/tmp,100M,100K \
-    ABORT,${TMPDIR},100M,1K \
-    ABORT,${DL_DIR},100M,1K \
-    ABORT,${SSTATE_DIR},100M,1K \
-    ABORT,/tmp,10M,1K"
-
-#
 # Shared-state files from other locations
 #
 # As mentioned above, shared state files are prebuilt cache data objects which can

--- a/yocto/arm64/multiconfig/container.conf
+++ b/yocto/arm64/multiconfig/container.conf
@@ -181,26 +181,6 @@ USER_CLASSES ?= "buildstats image-mklibs image-prelink"
 PATCHRESOLVE = "noop"
 
 #
-# Disk Space Monitoring during the build
-#
-# Monitor the disk space during the build. If there is less that 1GB of space or less
-# than 100K inodes in any key build location (TMPDIR, DL_DIR, SSTATE_DIR), gracefully
-# shutdown the build. If there is less that 100MB or 1K inodes, perform a hard abort
-# of the build. The reason for this is that running completely out of space can corrupt
-# files and damages the build in ways which may not be easily recoverable.
-# It's necesary to monitor /tmp, if there is no space left the build will fail
-# with very exotic errors.
-BB_DISKMON_DIRS ??= "\
-    STOPTASKS,${TMPDIR},1G,100K \
-    STOPTASKS,${DL_DIR},1G,100K \
-    STOPTASKS,${SSTATE_DIR},1G,100K \
-    STOPTASKS,/tmp,100M,100K \
-    ABORT,${TMPDIR},100M,1K \
-    ABORT,${DL_DIR},100M,1K \
-    ABORT,${SSTATE_DIR},100M,1K \
-    ABORT,/tmp,10M,1K"
-
-#
 # Shared-state files from other locations
 #
 # As mentioned above, shared state files are prebuilt cache data objects which can

--- a/yocto/arm64/multiconfig/container_arm64.conf
+++ b/yocto/arm64/multiconfig/container_arm64.conf
@@ -181,26 +181,6 @@ USER_CLASSES ?= "buildstats image-mklibs image-prelink"
 PATCHRESOLVE = "noop"
 
 #
-# Disk Space Monitoring during the build
-#
-# Monitor the disk space during the build. If there is less that 1GB of space or less
-# than 100K inodes in any key build location (TMPDIR, DL_DIR, SSTATE_DIR), gracefully
-# shutdown the build. If there is less that 100MB or 1K inodes, perform a hard abort
-# of the build. The reason for this is that running completely out of space can corrupt
-# files and damages the build in ways which may not be easily recoverable.
-# It's necesary to monitor /tmp, if there is no space left the build will fail
-# with very exotic errors.
-BB_DISKMON_DIRS ??= "\
-    STOPTASKS,${TMPDIR},1G,100K \
-    STOPTASKS,${DL_DIR},1G,100K \
-    STOPTASKS,${SSTATE_DIR},1G,100K \
-    STOPTASKS,/tmp,100M,100K \
-    ABORT,${TMPDIR},100M,1K \
-    ABORT,${DL_DIR},100M,1K \
-    ABORT,${SSTATE_DIR},100M,1K \
-    ABORT,/tmp,10M,1K"
-
-#
 # Shared-state files from other locations
 #
 # As mentioned above, shared state files are prebuilt cache data objects which can

--- a/yocto/generic/local.conf
+++ b/yocto/generic/local.conf
@@ -1,4 +1,4 @@
-USER_CLASSES ?= "buildstats image-mklibs image-prelink"
+USER_CLASSES ?= "buildstats"
 
 PATCHRESOLVE = "noop"
 

--- a/yocto/generic/local.conf
+++ b/yocto/generic/local.conf
@@ -7,11 +7,12 @@ BB_DISKMON_DIRS ??= "\
     STOPTASKS,${DL_DIR},1G,100K \
     STOPTASKS,${SSTATE_DIR},1G,100K \
     STOPTASKS,/tmp,100M,100K \
-    ABORT,${TMPDIR},100M,1K \
-    ABORT,${DL_DIR},100M,1K \
-    ABORT,${SSTATE_DIR},100M,1K \
-    ABORT,/tmp,10M,1K"
+    HALT,${TMPDIR},100M,1K \
+    HALT,${DL_DIR},100M,1K \
+    HALT,${SSTATE_DIR},100M,1K \
+    HALT,/tmp,10M,1K"
 
-PACKAGECONFIG_append_pn-qemu-native = " sdl"
-PACKAGECONFIG_append_pn-nativesdk-qemu = " sdl"
-PACKAGECONFIG_pn-btrfs-tools = ""
+PACKAGECONFIG:append:pn-qemu-native = " sdl"
+PACKAGECONFIG:append:pn-qemu-system-native = " sdl"
+PACKAGECONFIG:append:pn-nativesdk-qemu = " sdl"
+PACKAGECONFIG:pn-btrfs-tools = ""

--- a/yocto/init_ws_ids.sh
+++ b/yocto/init_ws_ids.sh
@@ -94,7 +94,7 @@ if [ ${SKIP_CONFIG} != 1 ]; then
 	for layer in ${METAS}; do
 		echo adding layer ${SRC_DIR}/${layer}
 		if [ ${layer} == "meta-virtualization" ]; then
-			echo "DISTRO_FEATURES_append = \" virtualization\"" >> ${BUILD_DIR}/conf/local.conf
+			echo "DISTRO_FEATURES:append = \" virtualization\"" >> ${BUILD_DIR}/conf/local.conf
 		fi
 
 		bitbake-layers add-layer ${SRC_DIR}/${layer}
@@ -134,7 +134,7 @@ if [ ${SKIP_CONFIG} != 1 ]; then
 	fi
 
 	# enable SecureBoot support in OVMF
-	echo 'PACKAGECONFIG_append_pn-ovmf = " secureboot"' >> ${BUILD_DIR}/conf/local.conf
+	echo 'PACKAGECONFIG:append:pn-ovmf = " secureboot"' >> ${BUILD_DIR}/conf/local.conf
 fi
 
 

--- a/yocto/x86/genericx86-64/local.conf
+++ b/yocto/x86/genericx86-64/local.conf
@@ -21,11 +21,11 @@ PACKAGE_CLASSES = "package_ipk"
 BBMULTICONFIG = "container installer"
 
 PREFERRED_PROVIDER_virtual/kernel ?= "linux-vanilla"
-PREFERRED_PROVIDER_virtual/kernel_poky-tiny ?= "linux-vanilla"
+PREFERRED_PROVIDER_virtual/kernel:poky-tiny ?= "linux-vanilla"
 
 INITRAMFS_MODULES = ""
 
 INITRAMFS_MAXSIZE = "150000"
 
-PACKAGE_INSTALL_append_pn-trustx-cml-initramfs = "${INITRAMFS_MODULES}"
-PACKAGE_INSTALL_append_pn-trustx-installer-initramfs = "${INITRAMFS_MODULES}"
+PACKAGE_INSTALL:append:pn-trustx-cml-initramfs = "${INITRAMFS_MODULES}"
+PACKAGE_INSTALL:append:pn-trustx-installer-initramfs = "${INITRAMFS_MODULES}"

--- a/yocto/x86/multiconfig/container.conf
+++ b/yocto/x86/multiconfig/container.conf
@@ -8,18 +8,17 @@ USER_CLASSES ?= "buildstats"
 
 PATCHRESOLVE = "noop"
 
+PACKAGECONFIG:append:pn-qemu-native = " sdl"
+PACKAGECONFIG:append:pn-nativesdk-qemu = " sdl"
 
-PACKAGECONFIG_append_pn-qemu-native = " sdl"
-PACKAGECONFIG_append_pn-nativesdk-qemu = " sdl"
-
-CONF_VERSION = "1"
+CONF_VERSION = "2"
 
 PREFERRED_PROVIDER_virtual/kernel = "linux-dummy"
-PREFERRED_PROVIDER_virtual/kernel_poky-tiny = "linux-dummy"
-PREFERRED_PROVIDER_virtual/kernel_linuxstdbase = "linux-dummy"
+PREFERRED_PROVIDER_virtual/kernel:poky-tiny = "linux-dummy"
+PREFERRED_PROVIDER_virtual/kernel:linuxstdbase = "linux-dummy"
 
 DISTRO = "poky"
-#DISTRO_FEATURES_append = " virtualization"
+#DISTRO_FEATURES:append = " virtualization"
 
 IMAGE_FSTYPES = "cpio.gz ext4"
 INITRAMFS_IMAGE = ""

--- a/yocto/x86/multiconfig/container.conf
+++ b/yocto/x86/multiconfig/container.conf
@@ -8,15 +8,6 @@ USER_CLASSES ?= "buildstats image-mklibs image-prelink"
 
 PATCHRESOLVE = "noop"
 
-BB_DISKMON_DIRS ??= "\
-    STOPTASKS,${TMPDIR},1G,100K \
-    STOPTASKS,${DL_DIR},1G,100K \
-    STOPTASKS,${SSTATE_DIR},1G,100K \
-    STOPTASKS,/tmp,100M,100K \
-    ABORT,${TMPDIR},100M,1K \
-    ABORT,${DL_DIR},100M,1K \
-    ABORT,${SSTATE_DIR},100M,1K \
-    ABORT,/tmp,10M,1K"
 
 PACKAGECONFIG_append_pn-qemu-native = " sdl"
 PACKAGECONFIG_append_pn-nativesdk-qemu = " sdl"

--- a/yocto/x86/multiconfig/container.conf
+++ b/yocto/x86/multiconfig/container.conf
@@ -4,7 +4,7 @@ TMPDIR = "${TOPDIR}/tmp_container"
 
 EXTRA_IMAGE_FEATURES ?= "debug-tweaks"
 
-USER_CLASSES ?= "buildstats image-mklibs image-prelink"
+USER_CLASSES ?= "buildstats"
 
 PATCHRESOLVE = "noop"
 

--- a/yocto/x86/multiconfig/installer.conf
+++ b/yocto/x86/multiconfig/installer.conf
@@ -1,19 +1,6 @@
 EXTRA_IMAGE_FEATURES ?= "debug-tweaks"
 USER_CLASSES ?= "buildstats image-mklibs image-prelink"
 PATCHRESOLVE = "noop"
-BB_DISKMON_DIRS ??= "\
-    STOPTASKS,${TMPDIR},1G,100K \
-    STOPTASKS,${DL_DIR},1G,100K \
-    STOPTASKS,${SSTATE_DIR},1G,100K \
-    STOPTASKS,/tmp,100M,100K \
-    ABORT,${TMPDIR},100M,1K \
-    ABORT,${DL_DIR},100M,1K \
-    ABORT,${SSTATE_DIR},100M,1K \
-    ABORT,/tmp,10M,1K"
-
-PACKAGECONFIG_append_pn-qemu-native = " sdl"
-PACKAGECONFIG_append_pn-nativesdk-qemu = " sdl"
-
 
 CONF_VERSION = "1"
 DISTRO_FEATURES_append = " virtualization"

--- a/yocto/x86/multiconfig/installer.conf
+++ b/yocto/x86/multiconfig/installer.conf
@@ -2,8 +2,12 @@ EXTRA_IMAGE_FEATURES ?= "debug-tweaks"
 USER_CLASSES ?= "buildstats"
 PATCHRESOLVE = "noop"
 
-CONF_VERSION = "1"
-DISTRO_FEATURES_append = " virtualization"
+PACKAGECONFIG:append:pn-qemu-native = " sdl"
+PACKAGECONFIG:append:pn-nativesdk-qemu = " sdl"
+
+
+CONF_VERSION = "2"
+DISTRO_FEATURES:append = " virtualization"
 MACHINE = "genericx86-64"
 
 DISTRO = "poky-tiny"

--- a/yocto/x86/multiconfig/installer.conf
+++ b/yocto/x86/multiconfig/installer.conf
@@ -1,5 +1,5 @@
 EXTRA_IMAGE_FEATURES ?= "debug-tweaks"
-USER_CLASSES ?= "buildstats image-mklibs image-prelink"
+USER_CLASSES ?= "buildstats"
 PATCHRESOLVE = "noop"
 
 CONF_VERSION = "1"


### PR DESCRIPTION
This PR contains the initial support for Yocto Kirkstone. Commits include updating syntax to the one enforced by kirkstone, removing deprecated user classes and removing redundant code snippets for disk monitoring.

More PRs enhancing the kirkstone support will follow, this is only the initial support which should suffice to build a CI setup for continuously testing further and more elaborate changes.