### PR TITLE
Fix broken cc_mode build

### DIFF
--- a/device_provisioning/oss_enrollment/config_creator/guestos_config_creator.py
+++ b/device_provisioning/oss_enrollment/config_creator/guestos_config_creator.py
@@ -100,7 +100,8 @@ def set_mounts_hashes( mounts ):
     return
 
 set_mounts_hashes( guestos.mounts )
-set_mounts_hashes( guestos.mounts_setup )
+if hasattr(guestos, 'mounts_setup'):
+    set_mounts_hashes( guestos.mounts_setup )
 
 try:
     with open(args.path_to_new_config, "w") as f:


### PR DESCRIPTION
The mounts_setup field is not present in the cc_mode version of guestos.proto, so do not set the field in cc_mode build otherwise build fails.