### PR TITLE
yocto/*/local.conf: switched from poky-tiny to gyroidos-cml distro

### DIFF
--- a/yocto/arm32/colibri-imx6ull/local.conf
+++ b/yocto/arm32/colibri-imx6ull/local.conf
@@ -1,5 +1,5 @@
 MACHINE="colibri-imx6ull"
-DISTRO="poky-tiny"
+DISTRO="gyroidos-cml"
 
 PREFERRED_PROVIDER_virtual/kernel_colibri-imx6ull = "linux-toradex"
 COMPATIBLE_MACHINE_colibri-imx6ull = "colibri-imx6ull"

--- a/yocto/arm32/nitrogen6x/local.conf
+++ b/yocto/arm32/nitrogen6x/local.conf
@@ -1,5 +1,5 @@
 MACHINE="nitrogen6x"
-DISTRO="poky-tiny"
+DISTRO="gyroidos-cml"
 MACHINEOVERRIDES .= ":use-mainline-bsp"
 PREFERRED_PROVIDER_virtual/bootloader = "u-boot-fslc"
 PREFERRED_PROVIDER_u-boot = "u-boot-fslc"

--- a/yocto/arm32/qemuarm/local.conf
+++ b/yocto/arm32/qemuarm/local.conf
@@ -1,6 +1,6 @@
 MACHINE = "qemuarm"
 
-DISTRO = "poky-tiny"
+DISTRO = "gyroidos-cml"
 
 INITRAMFS_IMAGE_BUNDLE = "1"
 INITRAMFS_IMAGE = "trustx-cml-initramfs"

--- a/yocto/arm32/raspberrypi2/local.conf
+++ b/yocto/arm32/raspberrypi2/local.conf
@@ -1,7 +1,7 @@
 MACHINE="raspberrypi2"
-DISTRO="poky-tiny"
+DISTRO="gyroidos-cml"
 PREFERRED_PROVIDER_virtual/kernel ?= "linux-raspberrypi"
-PREFERRED_PROVIDER_virtual/kernel_poky-tiny = "linux-raspberrypi"
+PREFERRED_PROVIDER_virtual/kernel_gyroidos-cml ?= "linux-raspberrypi"
 PREFERRED_VERSION_linux-raspberrypi = "5.15.%"
 
 RPI_KERNEL_DEVICETREE_OVERLAYS += " overlays/tpm-slb9670.dtbo"

--- a/yocto/arm64/colibri-imx8x/local.conf
+++ b/yocto/arm64/colibri-imx8x/local.conf
@@ -1,5 +1,5 @@
 MACHINE="colibri-imx8x"
-DISTRO="poky-tiny"
+DISTRO="gyroidos-cml"
 
 PREFERRED_PROVIDER_virtual/kernel_colibri-imx8x = "linux-toradex"
 COMPATIBLE_MACHINE_colibri-imx8x = "colibri-imx8x"

--- a/yocto/arm64/qemuarm/local.conf
+++ b/yocto/arm64/qemuarm/local.conf
@@ -1,6 +1,6 @@
 MACHINE = "qemuarm"
 
-DISTRO = "poky-tiny"
+DISTRO = "gyroidos-cml"
 
 INITRAMFS_IMAGE_BUNDLE = "1"
 INITRAMFS_IMAGE = "trustx-cml-initramfs"

--- a/yocto/arm64/raspberrypi3-64/local.conf
+++ b/yocto/arm64/raspberrypi3-64/local.conf
@@ -1,7 +1,7 @@
 MACHINE="raspberrypi3-64"
-DISTRO="poky-tiny"
+DISTRO="gyroidos-cml"
 PREFERRED_PROVIDER_virtual/kernel ?= "linux-raspberrypi"
-PREFERRED_PROVIDER_virtual/kernel_poky-tiny = "linux-raspberrypi"
+PREFERRED_PROVIDER_virtual/kernel_gyroidos-cml ?= "linux-raspberrypi"
 PREFERRED_VERSION_linux-raspberrypi = "5.15.%"
 
 RPI_KERNEL_DEVICETREE_OVERLAYS += " overlays/tpm-slb9670.dtbo"

--- a/yocto/arm64/zcu104-zynqmp/local.conf
+++ b/yocto/arm64/zcu104-zynqmp/local.conf
@@ -1,7 +1,7 @@
 MACHINE="zcu104-zynqmp"
-DISTRO="poky-tiny"
+DISTRO="gyroidos-cml"
 PREFERRED_PROVIDER_virtual/kernel = "linux-xlnx"
-PREFERRED_PROVIDER_virtual/kernel_poky-tiny = "linux-xlnx"
+PREFERRED_PROVIDER_virtual/kernel_gyroidos-cml = "linux-xlnx"
 PREFERRED_PROVIDER_virtual/boot-bin = "xilinx-bootbin"
 
 INITRAMFS_IMAGE_BUNDLE = "0"

--- a/yocto/x86/genericx86-64/local.conf
+++ b/yocto/x86/genericx86-64/local.conf
@@ -1,6 +1,6 @@
 MACHINE = "genericx86-64"
 
-DISTRO = "poky-tiny"
+DISTRO = "gyroidos-cml"
 
 INITRAMFS_IMAGE_BUNDLE = "1"
 INITRAMFS_IMAGE = "trustx-cml-initramfs"
@@ -21,7 +21,7 @@ PACKAGE_CLASSES = "package_ipk"
 BBMULTICONFIG = "container installer"
 
 PREFERRED_PROVIDER_virtual/kernel ?= "linux-vanilla"
-PREFERRED_PROVIDER_virtual/kernel_poky-tiny ?= "linux-vanilla"
+PREFERRED_PROVIDER_virtual/kernel_gyroidos-cml ?= "linux-vanilla"
 
 INITRAMFS_MODULES = ""
 


### PR DESCRIPTION
Make use of the newly introduced wrapper distro gyroidos-cml instead of directly use poky-tiny.