### PR TITLE
provisioning guestos_config_creator: do not generate empty verity hash

### DIFF
--- a/device_provisioning/oss_enrollment/config_creator/guestos_config_creator.py
+++ b/device_provisioning/oss_enrollment/config_creator/guestos_config_creator.py
@@ -92,7 +92,8 @@ def set_mounts_hashes( mounts ):
                     sha256.update(data)
                 mount.image_sha1 = sha1.hexdigest()
                 mount.image_sha2_256 = sha256.hexdigest()
-                mount.image_verity_sha256 = args.root_hash
+                if args.root_hash != "":
+                    mount.image_verity_sha256 = args.root_hash
         elif mount.mount_type == EMPTY:
             if mount.image_file == "data":
                 #print "Set default size for userdata of container to: " + args.def_size + "(Mb)"


### PR DESCRIPTION
In case the the config paramter for root_hash is not set an empty string is used as defaut. This leads to an empty image_verity_sha256 in the final protobuf-text config file. This is now checked so the image_vertity field will only be generated in the final config file if a root_hash was set.