### PR TITLE
cml_tools/gen_guestos.sh: Bugfix wrong root_hash

### DIFF
--- a/cml_tools/gen_guestos.sh
+++ b/cml_tools/gen_guestos.sh
@@ -68,7 +68,7 @@ do_sign_guestos () {
 
         root_hash=$(veritysetup format ${GUESTOS_OUT}/${name}os-${TRUSTME_VERSION}/root.img \
                     ${GUESTOS_OUT}/${name}os-${TRUSTME_VERSION}/root.hash.img | \
-                    tail -n 1 | \
+                    grep 'Root hash:' | \
                     cut -d ":" -f2 | \
                     tr -d '[:space:]')
 


### PR DESCRIPTION
Fixes a bug which caused gen_guestos.sh to store a wrong root_hash in the guestos config.