### PR TITLE
device_provisioning/oss_enrollment/config_creator/sign_config: PKCS#11

### DIFF
--- a/yocto/init_ws_ids.sh
+++ b/yocto/init_ws_ids.sh
@@ -72,14 +72,6 @@ else
 	sed -i 's/##TRUSTME_SCHSM##/n/' ${BUILD_DIR}/conf/local.conf
 fi
 
-if [ ${SKIP_CONFIG} != 1 ]; then
-	echo "KERNEL_MODULE_SIG_KEY=\"${BUILD_DIR}/test_certificates/certs/signing_key.pem\"" >>  ${BUILD_DIR}/conf/local.conf
-	echo "KERNEL_SYSTEM_TRUSTED_KEYS=\"${BUILD_DIR}/test_certificates/ssig_rootca.cert\"" >>  ${BUILD_DIR}/conf/local.conf
-
-	sed -i "s/# random string to ignore SSTATE_MIRROR/# random string to ignore SSTATE_MIRROR: $(date +%s | sha1sum | awk '{print $1}')/" "${SRC_DIR}/meta-trustx/recipes-trustx/userdata/pki-native.bb"
-fi
-
-
 echo ""
 echo "--------------------------------------------"
 echo "[\${DEVELOPMENT_BUILD} = '${DEVELOPMENT_BUILD}']"


### PR DESCRIPTION
Enable guestos signing using PKCS#11 hardware. This commit allows to override the openssl binary using a environment variable OPENSSL. This is required since Yocto ludicrously wraps the openssl binary in a shell script that hardcodes env variable like OPENSSL_CONF. To provide our own openssl config file, we therefore need to use the 'openssl.real' binary in Yocto that is set through this variable.

We further check if the signing key is a PKCS#11 URI and, if so, add specific options to the openssl command.