### PR TITLE
yocto/init_ws_ids: support new sc cardservice related variable

### DIFF
--- a/yocto/init_ws_ids.sh
+++ b/yocto/init_ws_ids.sh
@@ -73,6 +73,13 @@ if ! grep -q '##TRUSTME_HARDWARE##' ${BUILD_DIR}/conf/local.conf;then
 		echo "Not enabling sc-hsm support"
 		sed -i 's/##TRUSTME_SCHSM##/n/' ${BUILD_DIR}/conf/local.conf
 	fi
+	if [ "${ENABLE_BNSE}" = "1" ]; then
+		echo "Enabling bnse support"
+		sed -i 's/##TRUSTME_BNSE##/y/' ${BUILD_DIR}/conf/local.conf
+	else
+		echo "Not enabling bnse support"
+		sed -i 's/##TRUSTME_BNSE##/n/' ${BUILD_DIR}/conf/local.conf
+	fi
 
 	if [ "${TRUSTME_SANITIZERS}" = "1" ]; then
 	       echo "Enabling sanitizers for cmld"


### PR DESCRIPTION
This commit introduces support for the new variable TRUSTME_BNSE introduced in PR gyroidos/meta-trustx#252