### PR TITLE
yocto: meta-trustx* is now meta-gyroidos*

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@ pipeline {
 	agent any
 
 	parameters {
-		string(name: 'PR_BRANCHES', defaultValue: '', description: 'Comma separated list of additional pull request branches (e.g. meta-trustx=PR-177,meta-trustx-nxp=PR-13,gyroidos_build=PR-97)')
+		string(name: 'PR_BRANCHES', defaultValue: '', description: 'Comma separated list of additional pull request branches (e.g. meta-gyroidos=PR-177,meta-gyroidos-nxp=PR-13,gyroidos_build=PR-97)')
 	}
 
 	stages {

--- a/yocto/README.md
+++ b/yocto/README.md
@@ -89,8 +89,8 @@ Temporarily
 ```
 
 Persistently
-* Add file to meta-trustx/recipes-kernel/linux/files
-* Register new file in .bbappend files inside meta-trustx/recipes-kernel/linux/
+* Add file to meta-gyroidos/recipes-kernel/linux/files
+* Register new file in .bbappend files inside meta-gyroidos/recipes-kernel/linux/
 
 # Description
 
@@ -120,8 +120,8 @@ Persistently
    bitbake gyroidos-cml-initramfs
 ```
 
-   - Distro config: meta-trustx/conf/distro/cml-tiny.conf
-   - Image-BB: meta-trustx/image/gyroidos-cml-initramfs.bb
+   - Distro config: meta-gyroidos/conf/distro/cml-tiny.conf
+   - Image-BB: meta-gyroidos/image/gyroidos-cml-initramfs.bb
    - this generates a test PKI if none is present inside the out-yocto directory
 
 

--- a/yocto/arm32/colibri-imx6ull/metas.inc
+++ b/yocto/arm32/colibri-imx6ull/metas.inc
@@ -2,7 +2,7 @@ BBLAYERS += " \
   ${OEROOT}/meta-freescale \
   ${OEROOT}/meta-freescale-3rdparty \
   ${OEROOT}/meta-freescale-distro \
-  ${OEROOT}/meta-trustx-nxp \
+  ${OEROOT}/meta-gyroidos-nxp \
   ${OEROOT}/meta-toradex-bsp-common \
   ${OEROOT}/meta-toradex-nxp \
 "

--- a/yocto/arm32/nitrogen6x/metas.inc
+++ b/yocto/arm32/nitrogen6x/metas.inc
@@ -2,5 +2,5 @@ BBLAYERS += " \
   ${OEROOT}/meta-freescale \
   ${OEROOT}/meta-freescale-3rdparty \
   ${OEROOT}/meta-freescale-distro \
-  ${OEROOT}/meta-trustx-nxp \
+  ${OEROOT}/meta-gyroidos-nxp \
 "

--- a/yocto/arm32/raspberrypi2/metas.inc
+++ b/yocto/arm32/raspberrypi2/metas.inc
@@ -1,4 +1,4 @@
 BBLAYERS += " \
   ${OEROOT}/meta-raspberrypi \
-  ${OEROOT}/meta-trustx-rpi \
+  ${OEROOT}/meta-gyroidos-rpi \
 "

--- a/yocto/arm64/apalis-imx8/metas.inc
+++ b/yocto/arm64/apalis-imx8/metas.inc
@@ -2,7 +2,7 @@ BBLAYERS += " \
   ${OEROOT}/meta-freescale \
   ${OEROOT}/meta-freescale-3rdparty \
   ${OEROOT}/meta-freescale-distro \
-  ${OEROOT}/meta-trustx-nxp \
+  ${OEROOT}/meta-gyroidos-nxp \
   ${OEROOT}/meta-toradex-bsp-common \
   ${OEROOT}/meta-toradex-nxp \
 "

--- a/yocto/arm64/colibri-imx8x/metas.inc
+++ b/yocto/arm64/colibri-imx8x/metas.inc
@@ -2,7 +2,7 @@ BBLAYERS += " \
   ${OEROOT}/meta-freescale \
   ${OEROOT}/meta-freescale-3rdparty \
   ${OEROOT}/meta-freescale-distro \
-  ${OEROOT}/meta-trustx-nxp \
+  ${OEROOT}/meta-gyroidos-nxp \
   ${OEROOT}/meta-toradex-bsp-common \
   ${OEROOT}/meta-toradex-nxp \
 "

--- a/yocto/arm64/nvidia-jetson/metas.inc
+++ b/yocto/arm64/nvidia-jetson/metas.inc
@@ -1,4 +1,0 @@
-BBLAYERS += " \
-  ${OEROOT}/meta-tegra \
-  ${OEROOT}/meta-trustx-tegra \
-"

--- a/yocto/arm64/raspberrypi3-64/metas.inc
+++ b/yocto/arm64/raspberrypi3-64/metas.inc
@@ -1,4 +1,4 @@
 BBLAYERS += " \
   ${OEROOT}/meta-raspberrypi \
-  ${OEROOT}/meta-trustx-rpi \
+  ${OEROOT}/meta-gyroidos-rpi \
 "

--- a/yocto/arm64/tqma8mpxl/metas.inc
+++ b/yocto/arm64/tqma8mpxl/metas.inc
@@ -1,5 +1,5 @@
 BBLAYERS += " \
   ${OEROOT}/meta-freescale \
-  ${OEROOT}/meta-trustx-nxp \
+  ${OEROOT}/meta-gyroidos-nxp \
   ${OEROOT}/meta-tq/meta-tq \
 "

--- a/yocto/docker/README.md
+++ b/yocto/docker/README.md
@@ -9,7 +9,7 @@ repo init -u https://github.com/gyroidos/gyroidos.git -b master -m ids-x86-yocto
 ## Build Docker image
 ```
 cd ~/ws-yocto/gyroidos/build/yocto/docker
-docker build -t trustx-builder .
+docker build -t gyroidos-builder .
 ```
 ## Start Docker
 ```

--- a/yocto/docker/run-docker.sh
+++ b/yocto/docker/run-docker.sh
@@ -73,7 +73,7 @@ main() {
         -v /home/$(id -un)/.ssh/known_hosts:/home/builder/.ssh/known_hosts \
         --env=LANG=en_US.UTF-8 \
         --env=LANGUAGE=en_US.UTF-8 \
-        trustx-builder \
+        gyroidos-builder \
         bash
 }
 

--- a/yocto/init_ws_container.sh
+++ b/yocto/init_ws_container.sh
@@ -52,7 +52,7 @@ if [ ${SKIP_CONFIG} != 1 ]; then
 	bitbake-layers add-layer ${SRC_DIR}/meta-openembedded/meta-filesystems
 	bitbake-layers add-layer ${SRC_DIR}/meta-virtualization
 	bitbake-layers add-layer ${SRC_DIR}/meta-selinux
-	bitbake-layers add-layer ${SRC_DIR}/meta-trustx
+	bitbake-layers add-layer ${SRC_DIR}/meta-gyroidos
 
 	echo 'FETCHCMD_wget = "/usr/bin/env wget -t 2 -T 30 --passive-ftp --no-check-certificate"' >> ${BUILD_DIR}/conf/local.conf
 	mkdir -p ${BUILD_DIR}/conf/multiconfig

--- a/yocto/init_ws_fde.sh
+++ b/yocto/init_ws_fde.sh
@@ -26,7 +26,7 @@ SRC_DIR=$(pwd)
 BUILD_DIR=${SRC_DIR}/$1
 DEVICE=$2
 
-METAS="meta-intel meta-openembedded/meta-oe meta-openembedded/meta-python meta-selinux meta-trustx meta-tpm2d-fde"
+METAS="meta-intel meta-openembedded/meta-oe meta-openembedded/meta-python meta-selinux meta-gyroidos meta-tpm2d-fde"
 
 if [ -z ${DEVICE} ]; then
 	echo "\${DEVICE} not set, falling back to \"x86\""

--- a/yocto/init_ws_ids.sh
+++ b/yocto/init_ws_ids.sh
@@ -44,7 +44,7 @@ if [ -d ${BUILD_DIR}/conf ]; then
 	SKIP_CONFIG=1
 fi
 
-export TEMPLATECONF=${SRC_DIR}/meta-trustx/conf/templates/default
+export TEMPLATECONF=${SRC_DIR}/meta-gyroidos/conf/templates/default
 source ${SRC_DIR}/poky/oe-init-build-env ${BUILD_DIR}
 # will change to build dir
 

--- a/yocto/x86/genericx86-64/metas.inc
+++ b/yocto/x86/genericx86-64/metas.inc
@@ -1,3 +1,3 @@
 BBLAYERS += " \
-  ${OEROOT}/meta-trustx-intel \
+  ${OEROOT}/meta-gyroidos-intel \
 "


### PR DESCRIPTION
With new upstream repo name changes, also the checkout to the local
folders was renamed in the repo manifests. Thus, use the new names
meta-gyrodios* here, too.