### PR TITLE
yocto/riscv: Added cv64a6-genesys2 support

### DIFF
--- a/yocto/riscv/cv64a6-genesys2/metas.inc
+++ b/yocto/riscv/cv64a6-genesys2/metas.inc
@@ -1,0 +1,4 @@
+BBLAYERS += " \
+  ${OEROOT}/meta-cva6-yocto \
+  ${OEROOT}/meta-gyroidos-cva6 \
+"


### PR DESCRIPTION
Support for building for the cv64a6-genesys2 on FPGA board by adding the corresponding layer config file 'metas.inc'.