### PR TITLE
device_provisioning/oss_enrollment: readd provisioning_lib.sh

### DIFF
--- a/device_provisioning/oss_enrollment/provisioning_lib.sh
+++ b/device_provisioning/oss_enrollment/provisioning_lib.sh
@@ -1,0 +1,22 @@
+error_check(){
+if [ "$1" != "0" ]; then
+  echo "Error: $2"
+  cleanup
+  exit 1
+fi
+}
+
+assert_file_exists(){
+if [ ! -f $1 ]; then 
+  echo "Error: Missing file $1"
+  cleanup
+  exit 1
+fi
+}
+
+assert_file_not_exists(){
+if [ -f $1 ]; then 
+  echo "Error: File $1 exists. Precautional exit"
+  exit 1
+fi
+}


### PR DESCRIPTION
Readd accidentally deleted provisioning_lib.sh. This is needed for error checking and assertions in pki generation scripts.

Fixes: f012abe397a1 ("device_provisioning: cleanup of PKI generation scripts")