### PR TITLE
yocto/init_ws-ids: Pass DEV_SSH_PUBKEY variable to local.conf

### DIFF
--- a/yocto/init_ws_ids.sh
+++ b/yocto/init_ws_ids.sh
@@ -121,5 +121,11 @@ if [ "${DEVELOPMENT_BUILD}" == "n" ]; then
 	echo "### RELEASE_BUILD ###"
 else
 	echo "### DEVELOPMENT_BUILD ###"
+	if [ -z "${DEV_SSH_PUBKEY}" ]; then
+		echo "SSH Public key for system access not set"
+		sed -i "s/##DEV_SSH_PUBKEY##//" "${BUILD_DIR}/conf/local.conf"
+	else
+		sed -i "s|##DEV_SSH_PUBKEY##|${DEV_SSH_PUBKEY}|" "${BUILD_DIR}"/conf/local.conf
+	fi
 fi
 echo "--------------------------------------------"


### PR DESCRIPTION
This allows to define the DEV_SSH_PUBKEY variable for the PR (https://github.com/gyroidos/meta-gyroidos/pull/297) in meta-gyroidos