### PR TITLE
gen_dev_certs: serialize concurrent runs and publish certs atomically

### DIFF
--- a/device_provisioning/gen_dev_certs.sh
+++ b/device_provisioning/gen_dev_certs.sh
@@ -36,11 +36,22 @@ else
 	OUT_CERTS_DIR="${SELF_DIR}/test_certificates"
 fi
 
+# Multiple recipes/multiconfigs invoke this concurrently with the same
+# OUT_CERTS_DIR. Serialize them on a dedicated lock (NOT ${OUT_CERTS_DIR}.lock,
+# which pki-native holds while calling us -> self-deadlock).
+exec 9>"${OUT_CERTS_DIR}.genlock"
+flock 9
+
 if [ -d "${OUT_CERTS_DIR}" ]; then
 	echo "Test Certificates already generated!"
 	exit 0
 fi
-mkdir "${OUT_CERTS_DIR}"
+
+# Generate into a staging dir and publish via atomic rename, so consumers never
+# see a half-generated dir. Clean up the staging dir on failure.
+FINAL_CERTS_DIR="${OUT_CERTS_DIR}"
+OUT_CERTS_DIR="$(mktemp -d "${FINAL_CERTS_DIR}.tmp.XXXXXX")"
+trap 'rm -rf "${OUT_CERTS_DIR}"' EXIT
 
 ##############################################
 ########## Software Signing PKI ##############
@@ -80,5 +91,9 @@ done
 for i in txt old attr pem; do
 	rm "${CERTS_DIR}/"*."${i}"
 done
+
+# Publish atomically (same filesystem -> single rename).
+mv "${OUT_CERTS_DIR}" "${FINAL_CERTS_DIR}"
+trap - EXIT
 
 exit 0


### PR DESCRIPTION
This PR is part of the endeavors of fixing the PKI race conditions when multiple bitbake targets run at once. Previous changes serialized prior races. This PR fixes a further race condition, and proofs against future races by making the generation of the PKI files into the filesystem an atomic operation. We achieve this by moving (`mv`-ing) the fully populated PKI infra into place.

Multiple recipes/multiconfigs invoke this with the same OUT_CERTS_DIR, racing on the shared test_certificates dir. Take an flock and generate into a staging dir published via atomic rename, so consumers never see a half-generated cert set (e.g. missing ssig_subca.key).