### PR TITLE
yocto/init_ws_ids: Substitute CI_CONSOLE_REDIRECT into local.conf

### DIFF
--- a/yocto/init_ws_ids.sh
+++ b/yocto/init_ws_ids.sh
@@ -66,6 +66,14 @@ else
 	sed -i "s|##CC_MODE##|n|g" "${BUILD_DIR}/conf/local.conf"
 fi
 
+# Defaults to "y" (CI console capture on); set CI_CONSOLE_REDIRECT=n to build a
+# hardware-deployable image without redirecting the console to the CI serial.
+if [[ "${CI_CONSOLE_REDIRECT:-}" == "n" ]]; then
+	sed -i "s|##CI_CONSOLE_REDIRECT##|n|g" "${BUILD_DIR}/conf/local.conf"
+else
+	sed -i "s|##CI_CONSOLE_REDIRECT##|y|g" "${BUILD_DIR}/conf/local.conf"
+fi
+
 sed -i "s|##UPSTREAM_VERSION##|${UPSTREAM_VERSION:-}|g" "${BUILD_DIR}/conf/local.conf"
 
 if ! grep -q '##GYROIDOS_HARDWARE##' "${BUILD_DIR}/conf/local.conf"; then


### PR DESCRIPTION
This PR captures QEMU {stdout,stderr}, kernel, and CML logs as build artifacts, controlled by a new CI_CONSOLE_REDIRECT toggle (Jenkins parameter, default `y`). It also reworks how the kernel command line is built so per-layer and per-board contributions compose instead of clobbering each other, and decouples the console redirect from `DEVELOPMENT_BUILD` — dev images are deployed to real hardware, where a CI serial backend is wrong/absent, so a deployable image can now be built from any buildtype by setting `CI_CONSOLE_REDIRECT=n`.

## [meta-gyroidos](https://github.com/gyroidos/meta-gyroidos/pull/309)
- Composable kernel command line in `recipes-kernel/linux/linux-gyroidos.inc`. `GYROIDOS_KERNEL_CMDLINE` is assembled from three parts and committed by `kernel_do_configure:append` into the merged `.config` (after `merge_config.sh`), so it wins the merge-order race that previously dropped the base `audit=1`:
    - `audit=1` baseline policy;
      - `GYROIDOS_KERNEL_CMDLINE_BASE` — per-machine, always-on board args (serial console, root device). BSP boards (apalis-imx8, colibri-imx8x, colibri-imx6ull, raspberrypi3-64) shipped these in their `.cfg`/defconfig `CONFIG_CMDLINE`; since the append overwrites `CONFIG_CMDLINE` wholesale, those values are folded in here as machine overrides rather than silently lost. Centralized in the base layer so the `-nxp`/`-rpi` layers are untouched; the now-dead BSP `CONFIG_CMDLINE` lines can be removed later.
    - `GYROIDOS_KERNEL_CMDLINE_DEV` — per-machine CI serial-capture additions, included only when `CI_CONSOLE_REDIRECT=y`.
- New `CI_CONSOLE_REDIRECT` toggle: weak default `y` in the `cml-base` distro, plumbed through the `local.conf` template. Gates the dev/CI console redirect instead of `DEVELOPMENT_BUILD`.
- Dev/CI diagnostic fragment `recipes-initscripts/cml-boot/files/22-dump-diag.fragment` (now gated on `CI_CONSOLE_REDIRECT`) prints `/proc/cmdline`, `ls /dev/ttyS*`, and `$LOGTTY` to the CML log so routing can be verified from CI artifacts.

## [meta-gyroidos-intel](https://github.com/gyroidos/meta-gyroidos-intel/pull/53)
- `conf/gyroidos/genericx86-64.inc`: overrides `GYROIDOS_LOGTTY` to `ttyS2` (was `tty11`) so CML's existing `exec > /dev/$LOGTTY` writes directly to a QEMU serial backend — no bind mount, no init-script changes. Sets `GYROIDOS_KERNEL_CMDLINE_DEV` = `"earlycon=uart8250,io,0x2f8 console=ttyS1,115200"` to route kernel printk to ttyS1.
- New `recipes-initscripts/cml-boot/cml-boot_%.bbappend` adds a static `mknod /dev/ttyS2 c 4 66` so the early (pre-devtmpfs) `exec > /dev/$LOGTTY` can open it.
- All three are now gated on `CI_CONSOLE_REDIRECT` (default `y`) rather than `DEVELOPMENT_BUILD`; `GYROIDOS_LOGTTY` and the `/dev/ttyS2` node share the same gate so the node always exists when LOGTTY points at it.

## [meta-tmedbg](https://github.com/gyroidos/meta-tmedbg/pull/12)
- `recipes-kernel/linux/linux-%.bbappend` contributes `nokaslr` via `GYROIDOS_KERNEL_CMDLINE += "nokaslr"`. Previously `debugging.cfg` set `CONFIG_CMDLINE="nokaslr"` directly and won the merge race, silently dropping the base `audit=1` and the CI console routing.
- `recipes-kernel/linux/generic/debugging.cfg`: removed the `CONFIG_CMDLINE_BOOL` and `CONFIG_CMDLINE` lines; now owned in one place by meta-gyroidos.

## [gyroidos_ci_common](https://github.com/gyroidos/gyroidos_ci_common/pull/79)
- `resources/VM-management.sh`:
    - `start_vm()` passes three `-serial file:` backends (console.log / kernel.log / cml.log) and redirects QEMU stdout to `${PROCESS_NAME}.qemu.stdout` so usb-host warnings (and similar) land in the artifact set.
    - `fetch_logs()` iterates over the three log files plus stderr+stdout with one consistent if-present-then-copy block.
    - `force_stop_vm()` waits up to 15s for the QEMU process to exit after the quit monitor command (then SIGKILLs). Fixes a latent USB passthrough race in the hwhsm test: the extra `-serial file:` backends slow QEMU's flush on exit enough that the next `start_vm` would launch before the previous QEMU released its `-device usb-host` claim, causing `lsusb` in the guest to show no HSM device and signedcontainer1 to fail with `CONTAINER_START_TOKEN_UNINIT`.
- `vars/stepBuildImage.groovy`: exports the `CI_CONSOLE_REDIRECT` job parameter (default `y`) into the build environment so `init_ws_ids.sh` writes it to `local.conf`.

## [gyroidos](https://github.com/gyroidos/gyroidos/pull/112)
- `Jenkinsfile`: new `CI_CONSOLE_REDIRECT` choice parameter (default `y`) controlling whether the kernel/CML console is redirected to the CI serial backend for log capture. Set to `n` to build a hardware-deployable image.

## [gyroidos_build](https://github.com/gyroidos/gyroidos_build/pull/139)
- `yocto/init_ws_ids.sh`: substitutes the `##CI_CONSOLE_REDIRECT##` placeholder in the `local.conf` template (defaulting to `y` when unset), mirroring the existing `DEVELOPMENT_BUILD`/`CC_MODE` substitution, so the Jenkins parameter reaches bitbake.
## [meta-gyroidos-nxp](https://github.com/gyroidos/meta-gyroidos-nxp/pull/44)
- Move the Toradex board serial-console arguments out of the per-machine `.cfg` fragments into `GYROIDOS_KERNEL_CMDLINE_BASE:<machine>` in the `linux-toradex` bbappend (apalis-imx8, colibri-imx8x, colibri-imx6ull). A plain `CONFIG_CMDLINE` is overwritten by meta-gyroidos's composable-cmdline append, so it must be contributed via the shared variable.

## [meta-gyroidos-rpi](https://github.com/gyroidos/meta-gyroidos-rpi/pull/23)
- Move the raspberrypi3-64 console + root-device arguments out of `bcmrpi3_defconfig` into `GYROIDOS_KERNEL_CMDLINE_BASE:raspberrypi3-64` in the `linux-raspberrypi` bbappend, for the same reason.